### PR TITLE
[feat] replace http-server by browser-sync

### DIFF
--- a/boilerplates/instantsearch.js/package.json.hbs
+++ b/boilerplates/instantsearch.js/package.json.hbs
@@ -2,7 +2,7 @@
   "name": "{{name}}",
   "version": "1.0.0",
   "scripts": {
-    "start": "node_modules/browser-sync/bin/browser-sync.js start --server --files ."
+    "start": "browser-sync start --server --files ."
   },
   "devDependencies": {
     "browser-sync": "^2.18.13"

--- a/boilerplates/instantsearch.js/package.json.hbs
+++ b/boilerplates/instantsearch.js/package.json.hbs
@@ -2,9 +2,9 @@
   "name": "{{name}}",
   "version": "1.0.0",
   "scripts": {
-    "start": "http-server"
+    "start": "node_modules/browser-sync/bin/browser-sync.js start --server --files ."
   },
   "devDependencies": {
-    "http-server": "^0.10.0"
+    "browser-sync": "^2.18.13"
   }
 }


### PR DESCRIPTION
- Update `start` command to enable live-reloading with the dev server