### PR TITLE
feat(version): add dynamic versioning

### DIFF
--- a/bin/create-instantsearch-app.js
+++ b/bin/create-instantsearch-app.js
@@ -5,63 +5,108 @@ const path = require('path');
 const program = require('commander');
 const prompt = require('prompt');
 const colors = require('colors');
+const algoliasearch = require('algoliasearch');
 
 const version = require('../package.json').version;
 const createProject = require('../lib/createProject.js');
+const { algolia } = require('../config');
 
-let opts = {};
-let targetFolderName;
+const client = algoliasearch(algolia.appId, algolia.apiKey);
+const index = client.initIndex(algolia.indexName);
 
-program
-  .version(version)
-  .arguments('<destination_folder>')
-  .option('--app-id <appId>', 'The application ID')
-  .option('--api-key <apiKey>', 'The Algolia search API key')
-  .option('--index-name <indexName>', 'The main index of your search')
-  .option(
-    '--main-attribute <attributeName>',
-    'The main searchable attribute of your index'
-  )
-  .action(function(dest, options) {
-    opts = options;
-    targetFolderName = dest;
-  })
-  .parse(process.argv);
+(async function() {
+  let latestVersion;
+  let allVersions;
 
-if (!targetFolderName) {
-  console.log(
-    'The folder name for the new instantsearch project was not provided 😲'.red
-  );
-  program.help();
-}
-
-console.log(
-  `Creating your new instantsearch app: ${targetFolderName.bold}`.green
-);
-
-let prompts = [
-  { name: 'appId', description: 'Application ID'.blue, required: true },
-  { name: 'apiKey', description: 'Search API key'.blue, required: true },
-  { name: 'indexName', description: 'Index name'.blue, required: true },
-  {
-    name: 'attributeName',
-    description: 'Main searchable attribute'.blue,
-    required: false,
-  },
-];
-
-prompt.message = '';
-prompt.override = opts;
-
-prompt.start();
-prompt.get(prompts, function(err, config) {
-  if (err) {
-    console.log('\nProject creation cancelled 😢'.red);
-    process.exit(0);
-  } else {
-    config.name = targetFolderName;
-    config.targetFolderName = path.join(process.cwd(), targetFolderName);
-    createProject(config);
-    console.log('Project successfully created 🚀'.green.bold);
+  try {
+    const content = await index.search('instantsearch.js');
+    const library = content.hits[0];
+    latestVersion = library.version;
+    allVersions = Object.keys(library.versions);
+  } catch (err) {
+    // `AlgoliaSearchNetworkError` can occur if offline.
+    // Defaults to the latest major version.
+    latestVersion = '2';
+    allVersions = [latestVersion];
   }
-});
+
+  let opts = {};
+  let targetFolderName;
+
+  program
+    .version(version)
+    .arguments('<destination_folder>')
+    .option('--app-id <appId>', 'The application ID')
+    .option('--api-key <apiKey>', 'The Algolia search API key')
+    .option('--index-name <indexName>', 'The main index of your search')
+    .option(
+      '--main-attribute <attributeName>',
+      'The main searchable attribute of your index'
+    )
+    .option('--lib-version <libVersion>', 'The InstantSearch.js library version')
+    .action(function(dest, options) {
+      opts = options;
+      targetFolderName = dest;
+    })
+    .parse(process.argv);
+
+  if (!targetFolderName) {
+    console.log(
+      'The folder name for the new instantsearch project was not provided 😲'
+        .red
+    );
+    program.help();
+  }
+
+  console.log(
+    `Creating your new instantsearch app: ${targetFolderName.bold}`.green
+  );
+
+  let prompts = [
+    {
+      name: 'appId',
+      description: 'Application ID'.blue,
+      required: true,
+    },
+    {
+      name: 'apiKey',
+      description: 'Search API key'.blue,
+      required: true,
+    },
+    {
+      name: 'indexName',
+      description: 'Index name'.blue,
+      required: true,
+    },
+    {
+      name: 'libVersion',
+      description: `InstantSearch version`.blue,
+      default: latestVersion,
+      required: false,
+      conform: value => allVersions.includes(value),
+      message:
+        "This version of InstantSearch.js doesn't exist (see https://yarnpkg.com/en/package/instantsearch.js)",
+    },
+    {
+      name: 'attributeName',
+      description: 'Main searchable attribute'.blue,
+      required: false,
+    },
+  ];
+
+  prompt.message = '';
+  prompt.override = opts;
+
+  prompt.start();
+  prompt.get(prompts, function(err, config) {
+    if (err) {
+      console.log('\nProject creation cancelled 😢'.red);
+      process.exit(0);
+    } else {
+      config.name = targetFolderName;
+      config.targetFolderName = path.join(process.cwd(), targetFolderName);
+      createProject(config);
+      console.log('Project successfully created 🚀'.green.bold);
+    }
+  });
+})();

--- a/bin/create-instantsearch-app.js
+++ b/bin/create-instantsearch-app.js
@@ -5,108 +5,81 @@ const path = require('path');
 const program = require('commander');
 const prompt = require('prompt');
 const colors = require('colors');
-const algoliasearch = require('algoliasearch');
 
-const version = require('../package.json').version;
-const createProject = require('../lib/createProject.js');
-const { algolia } = require('../config');
+const { version } = require('../package.json');
+const { fetchLatestVersion } = require('../lib/fetchVersions');
+const createProject = require('../lib/createProject');
 
-const client = algoliasearch(algolia.appId, algolia.apiKey);
-const index = client.initIndex(algolia.indexName);
+let opts = {};
+let targetFolderName;
 
-(async function() {
-  let latestVersion;
-  let allVersions;
+program
+  .version(version)
+  .arguments('<destination_folder>')
+  .option('--app-id <appId>', 'The application ID')
+  .option('--api-key <apiKey>', 'The Algolia search API key')
+  .option('--index-name <indexName>', 'The main index of your search')
+  .option(
+    '--main-attribute <attributeName>',
+    'The main searchable attribute of your index'
+  )
+  .action(function(dest, options) {
+    opts = options;
+    targetFolderName = dest;
+  })
+  .parse(process.argv);
 
-  try {
-    const content = await index.search('instantsearch.js');
-    const library = content.hits[0];
-    latestVersion = library.version;
-    allVersions = Object.keys(library.versions);
-  } catch (err) {
-    // `AlgoliaSearchNetworkError` can occur if offline.
-    // Defaults to the latest major version.
-    latestVersion = '2';
-    allVersions = [latestVersion];
-  }
-
-  let opts = {};
-  let targetFolderName;
-
-  program
-    .version(version)
-    .arguments('<destination_folder>')
-    .option('--app-id <appId>', 'The application ID')
-    .option('--api-key <apiKey>', 'The Algolia search API key')
-    .option('--index-name <indexName>', 'The main index of your search')
-    .option(
-      '--main-attribute <attributeName>',
-      'The main searchable attribute of your index'
-    )
-    .option('--lib-version <libVersion>', 'The InstantSearch.js library version')
-    .action(function(dest, options) {
-      opts = options;
-      targetFolderName = dest;
-    })
-    .parse(process.argv);
-
-  if (!targetFolderName) {
-    console.log(
-      'The folder name for the new instantsearch project was not provided 😲'
-        .red
-    );
-    program.help();
-  }
-
+if (!targetFolderName) {
   console.log(
-    `Creating your new instantsearch app: ${targetFolderName.bold}`.green
+    'The folder name for the new InstantSearch project was not provided 😲'.red
   );
+  program.help();
+}
 
-  let prompts = [
-    {
-      name: 'appId',
-      description: 'Application ID'.blue,
-      required: true,
-    },
-    {
-      name: 'apiKey',
-      description: 'Search API key'.blue,
-      required: true,
-    },
-    {
-      name: 'indexName',
-      description: 'Index name'.blue,
-      required: true,
-    },
-    {
-      name: 'libVersion',
-      description: `InstantSearch version`.blue,
-      default: latestVersion,
-      required: false,
-      conform: value => allVersions.includes(value),
-      message:
-        "This version of InstantSearch.js doesn't exist (see https://yarnpkg.com/en/package/instantsearch.js)",
-    },
-    {
-      name: 'attributeName',
-      description: 'Main searchable attribute'.blue,
-      required: false,
-    },
-  ];
+console.log(
+  `Creating your new InstantSearch app: ${targetFolderName.bold}`.green
+);
 
-  prompt.message = '';
-  prompt.override = opts;
+let prompts = [
+  {
+    name: 'appId',
+    description: 'Application ID'.blue,
+    required: true,
+  },
+  {
+    name: 'apiKey',
+    description: 'Search API key'.blue,
+    required: true,
+  },
+  {
+    name: 'indexName',
+    description: 'Index name'.blue,
+    required: true,
+  },
+  {
+    name: 'attributeName',
+    description: 'Main searchable attribute'.blue,
+    required: false,
+  },
+];
 
-  prompt.start();
-  prompt.get(prompts, function(err, config) {
-    if (err) {
-      console.log('\nProject creation cancelled 😢'.red);
-      process.exit(0);
-    } else {
-      config.name = targetFolderName;
-      config.targetFolderName = path.join(process.cwd(), targetFolderName);
-      createProject(config);
-      console.log('Project successfully created 🚀'.green.bold);
-    }
-  });
-})();
+prompt.message = '';
+prompt.override = opts;
+
+prompt.start();
+prompt.get(prompts, async (err, config) => {
+  if (err) {
+    console.log('\nProject creation cancelled 😢'.red);
+    process.exit(0);
+  }
+
+  config.name = targetFolderName;
+  config.targetFolderName = path.join(process.cwd(), targetFolderName);
+
+  const libVersion = await fetchLatestVersion();
+  const configWithVersion = Object.assign({}, config, { libVersion });
+
+  createProject(configWithVersion);
+
+  console.log('Project successfully created 🚀'.green.bold);
+});

--- a/boilerplates/instantsearch.js/index.html.hbs
+++ b/boilerplates/instantsearch.js/index.html.hbs
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.1.2/dist/instantsearch.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.1.2/dist/instantsearch-theme-algolia.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@{{libVersion}}/dist/instantsearch.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@{{libVersion}}/dist/instantsearch-theme-algolia.min.css">
     <link rel="stylesheet" type="text/css" href="main.css">
     <title>{{name}}</title>
   </head>
@@ -43,7 +43,7 @@
     </div>
 
     <!-- js -->
-    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.1.2/dist/instantsearch.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@{{libVersion}}/dist/instantsearch.min.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  algolia: {
+    appId: 'OFCNCOG2CU',
+    apiKey: 'f54e21fa3a2a0160595bb058179bfb1e',
+    indexName: 'npm-search',
+  },
+};

--- a/config/index.js
+++ b/config/index.js
@@ -1,7 +1,0 @@
-module.exports = {
-  algolia: {
-    appId: 'OFCNCOG2CU',
-    apiKey: 'f54e21fa3a2a0160595bb058179bfb1e',
-    indexName: 'npm-search',
-  },
-};

--- a/lib/fetchVersions.js
+++ b/lib/fetchVersions.js
@@ -1,9 +1,13 @@
 const algoliasearch = require('algoliasearch');
 
-const { algolia } = require('../config');
+const algoliaConfig = {
+  appId: 'OFCNCOG2CU',
+  apiKey: 'f54e21fa3a2a0160595bb058179bfb1e',
+  indexName: 'npm-search',
+};
 
-const client = algoliasearch(algolia.appId, algolia.apiKey);
-const index = client.initIndex(algolia.indexName);
+const client = algoliasearch(algoliaConfig.appId, algoliaConfig.apiKey);
+const index = client.initIndex(algoliaConfig.indexName);
 
 const fetchLatestVersion = async () => {
   let libVersion;

--- a/lib/fetchVersions.js
+++ b/lib/fetchVersions.js
@@ -13,8 +13,7 @@ const fetchLatestVersion = async () => {
   let libVersion;
 
   try {
-    const results = await index.search('instantsearch.js');
-    const library = results.hits[0];
+    const library = await index.getObject('instantsearch.js');
     libVersion = library.version;
   } catch (err) {
     // `AlgoliaSearchNetworkError` can occur if offline.

--- a/lib/fetchVersions.js
+++ b/lib/fetchVersions.js
@@ -1,0 +1,32 @@
+const algoliasearch = require('algoliasearch');
+
+const { algolia } = require('../config');
+
+const client = algoliasearch(algolia.appId, algolia.apiKey);
+const index = client.initIndex(algolia.indexName);
+
+const fetchLatestVersion = async () => {
+  let libVersion;
+
+  try {
+    const results = await index.search('instantsearch.js');
+    const library = results.hits[0];
+    libVersion = library.version;
+  } catch (err) {
+    // `AlgoliaSearchNetworkError` can occur if offline.
+    // Defaults to the latest major version.
+    libVersion = '2';
+
+    console.warn(
+      "⚠️ We couldn't fetch the latest instantsearch.js version as you seem to be offline.\n" +
+        'instantsearch.js@2 has been added to your project.\n' +
+        "Make sure to explicitely set the latest version when you're back online: https://yarnpkg.com/en/package/instantsearch.js"
+    );
+  }
+
+  return libVersion;
+};
+
+module.exports = {
+  fetchLatestVersion,
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   "scripts": {
     "format": "prettier --write *.{js,md,json}"
   },
+  "engines": {
+    "node": ">= 7.6"
+  },
   "dependencies": {
+    "algoliasearch": "^3.24.9",
     "colors": "^1.1.2",
     "commander": "^2.11.0",
     "jstransformer-handlebars": "^1.0.0",


### PR DESCRIPTION
This feature is needed for a guide I'm working on 😁

* Fetch instantsearch.js version based on the `npm-search` Algolia index
* Add prompt choice to use the instantsearch.js version (defaults to the latest one), rejects if the version doesn't exist
* If offline, default the instantsearch.js@2 (jsDelivr resolves it to the actual latest version, `2.4.1` as of now)
* Inject the version in the HTML template

Let me know if there are other ways to solve it!

*Note: Node >= 7.6 is necessary because I've used `async` functions.*