### PR TITLE
feat(v3): Add support for option override

### DIFF
--- a/src/createInstantSearchApp.js
+++ b/src/createInstantSearchApp.js
@@ -34,6 +34,8 @@ program
     '--main-attribute <mainAttribute>',
     'The main searchable attribute of your index'
   )
+  .option('--template <template>', 'The InstantSearch template to use')
+  .option('--no-installation', 'Ignore dependency installation')
   .action((dest, opts) => {
     cdPath = dest;
     appPath = path.join(__dirname, dest);
@@ -146,18 +148,20 @@ try {
   const installCommand = packageManager === 'yarn' ? 'yarn' : 'npm install';
   let hasInstalledDependencies = false;
 
-  try {
-    console.log();
-    console.log('📦  Installing dependencies...');
-    console.log();
+  if (program.installation) {
+    try {
+      console.log();
+      console.log('📦  Installing dependencies...');
+      console.log();
 
-    installDependencies({ appPath, initialDirectory, installCommand });
+      installDependencies({ appPath, initialDirectory, installCommand });
 
-    hasInstalledDependencies = true;
-  } catch (err) {
-    console.warn(
-      '⚠️  Dependencies could not have been installed. Please follow the commands below to proceed.'
-    );
+      hasInstalledDependencies = true;
+    } catch (err) {
+      console.warn(
+        '⚠️  Dependencies could not have been installed. Please follow the commands below to proceed.'
+      );
+    }
   }
 
   console.log();

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,6 +37,42 @@ function checkAppPath(path) {
   }
 }
 
+function getOptionsFromArguments(rawArgs) {
+  let argIndex = 0;
+
+  return rawArgs.reduce((allArgs, currentArg) => {
+    argIndex++;
+
+    const argumentName = currentArg.split('--')[1];
+    const argumentValue = rawArgs[argIndex];
+
+    return {
+      ...allArgs,
+      ...(currentArg.startsWith('--') && {
+        [argumentName]: argumentValue,
+      }),
+    };
+  }, {});
+}
+
+function isQuestionAsked({ question, args }) {
+  for (const optionName in args) {
+    if (question.name === optionName) {
+      // Skip if the arg in the command is valid
+      if (question.validate && question.validate(args[optionName])) {
+        return false;
+      }
+    } else {
+      // Skip if the question is optional and not given in the command
+      if (!question.validate) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 function isYarnAvailable() {
   try {
     execSync('yarnpkg --version', { stdio: 'ignore' });
@@ -54,6 +90,8 @@ function getLatestInstantSearchVersion() {
 module.exports = {
   checkAppName,
   checkAppPath,
+  getOptionsFromArguments,
+  isQuestionAsked,
   isYarnAvailable,
   getLatestInstantSearchVersion,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,20 +37,26 @@ function checkAppPath(path) {
   }
 }
 
+function camelCase(string) {
+  return string.replace(/-([a-z])/g, str => str[1].toUpperCase());
+}
+
 function getOptionsFromArguments(rawArgs) {
   let argIndex = 0;
 
   return rawArgs.reduce((allArgs, currentArg) => {
     argIndex++;
 
-    const argumentName = currentArg.split('--')[1];
+    if (!currentArg.startsWith('--')) {
+      return allArgs;
+    }
+
+    const argumentName = camelCase(currentArg.split('--')[1]);
     const argumentValue = rawArgs[argIndex];
 
     return {
       ...allArgs,
-      ...(currentArg.startsWith('--') && {
-        [argumentName]: argumentValue,
-      }),
+      [argumentName]: argumentValue,
     };
   }, {});
 }
@@ -62,11 +68,9 @@ function isQuestionAsked({ question, args }) {
       if (question.validate && question.validate(args[optionName])) {
         return false;
       }
-    } else {
+    } else if (!question.validate) {
       // Skip if the question is optional and not given in the command
-      if (!question.validate) {
-        return false;
-      }
+      return false;
     }
   }
 
@@ -94,4 +98,5 @@ module.exports = {
   isQuestionAsked,
   isYarnAvailable,
   getLatestInstantSearchVersion,
+  camelCase,
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -173,3 +173,17 @@ describe('isQuestionAsked', () => {
     })
   ).toBe(false);
 });
+
+describe('camelCase', () => {
+  test('with single word', () => {
+    expect(utils.camelCase('test')).toBe('test');
+  });
+
+  test('with caret-separated word', () => {
+    expect(utils.camelCase('app-id')).toBe('appId');
+  });
+
+  test('with caret-separated twice word', () => {
+    expect(utils.camelCase('instant-search-js')).toBe('instantSearchJs');
+  });
+});

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -73,3 +73,103 @@ describe('checkAppPath', () => {
     });
   });
 });
+
+describe('getOptionsFromArguments', () => {
+  test('with a single command', () => {
+    expect(
+      utils.getOptionsFromArguments('cmd --appId APP_ID'.split(' '))
+    ).toEqual({
+      appId: 'APP_ID',
+    });
+  });
+
+  test('with a multiple commands', () => {
+    expect(
+      utils.getOptionsFromArguments([
+        'cmd',
+        '--appId',
+        'APP_ID',
+        '--apiKey',
+        'API_KEY',
+        '--indexName',
+        'INDEX_NAME',
+        '--template',
+        'Vue InstantSearch',
+      ])
+    ).toEqual({
+      appId: 'APP_ID',
+      apiKey: 'API_KEY',
+      indexName: 'INDEX_NAME',
+      template: 'Vue InstantSearch',
+    });
+  });
+
+  test('with different commands', () => {
+    expect(
+      utils.getOptionsFromArguments(['yarn', 'start', '--appId', 'APP_ID'])
+    ).toEqual({
+      appId: 'APP_ID',
+    });
+
+    expect(
+      utils.getOptionsFromArguments(['node', 'index', '--appId', 'APP_ID'])
+    ).toEqual({
+      appId: 'APP_ID',
+    });
+
+    expect(
+      utils.getOptionsFromArguments([
+        'create-instantsearch-app',
+        '--appId',
+        'APP_ID',
+      ])
+    ).toEqual({
+      appId: 'APP_ID',
+    });
+  });
+});
+
+describe('isQuestionAsked', () => {
+  expect(
+    utils.isQuestionAsked({
+      question: { name: 'appId', validate: input => Boolean(input) },
+      args: { appId: undefined },
+    })
+  ).toBe(true);
+
+  expect(
+    utils.isQuestionAsked({
+      question: { name: 'appId', validate: input => Boolean(input) },
+      args: { appId: 'APP_ID' },
+    })
+  ).toBe(false);
+
+  expect(
+    utils.isQuestionAsked({
+      question: {
+        name: 'template',
+        validate: input => input !== 'InstantSearch.js',
+      },
+      args: { template: 'InstantSearch.js' },
+    })
+  ).toBe(true);
+
+  expect(
+    utils.isQuestionAsked({
+      question: {
+        name: 'template',
+        validate: input => input === 'InstantSearch.js',
+      },
+      args: { template: 'InstantSearch.js' },
+    })
+  ).toBe(false);
+
+  expect(
+    utils.isQuestionAsked({
+      question: {
+        name: 'mainAttribute',
+      },
+      args: { indexName: 'INDEX_NAME' },
+    })
+  ).toBe(false);
+});


### PR DESCRIPTION
This PR adds support for option override from the command-line for the v3.

## Example

```sh
create-instantsearch-app my-app --indexName MY_INDEX_NAME --template "InstantSearch.js"
```

Will not ask for `indexName` and `template` in the menu:

![Preview](https://user-images.githubusercontent.com/6137112/39771867-da173f58-52f3-11e8-8e04-45af068f79b9.gif)


This is needed for compiling templates to demos.

