### PR TITLE
feat(v3): Add option to select InstantSearch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "node": ">= 7.6"
   },
   "dependencies": {
+    "algoliasearch": "^3.27.1",
     "chalk": "^2.4.1",
     "commander": "^2.15.1",
     "inquirer": "^5.2.0",
     "jstransformer-handlebars": "^1.1.0",
+    "latest-semver": "^1.0.0",
     "metalsmith": "^2.3.0",
     "metalsmith-in-place": "^4.1.1",
     "metalsmith-rename": "^1.0.0",

--- a/src/createInstantSearchApp.js
+++ b/src/createInstantSearchApp.js
@@ -6,19 +6,22 @@ const process = require('process');
 const program = require('commander');
 const inquirer = require('inquirer');
 const chalk = require('chalk');
+const latestSemver = require('latest-semver');
 
 const buildApp = require('../tasks/buildApp');
 const installDependencies = require('../tasks/installDependencies');
+const fetchLibraryVersions = require('../tasks/fetchLibraryVersions');
 const {
   checkAppName,
   checkAppPath,
   getOptionsFromArguments,
   isQuestionAsked,
   isYarnAvailable,
-  getLatestInstantSearchVersion,
+  getLibraryName,
 } = require('./utils');
 const { version } = require('../package.json');
 
+const fallbackLibraryVersion = '1.0.0';
 let cdPath;
 let appPath;
 let options = {};
@@ -114,6 +117,45 @@ const questions = [
       return templates.includes(input);
     },
   },
+  {
+    type: 'list',
+    name: 'libraryVersion',
+    message: answers => `${answers.template} version`,
+    choices: async answers => {
+      const libraryName = getLibraryName(answers.template);
+
+      try {
+        const versions = await fetchLibraryVersions(libraryName);
+        const latestStableVersion = latestSemver(versions);
+
+        return [
+          new inquirer.Separator('Latest stable version'),
+          latestStableVersion,
+          new inquirer.Separator('All versions'),
+          ...versions,
+        ];
+      } catch (err) {
+        console.log();
+        console.error(
+          chalk.red(
+            `Cannot fetch versions for library "${chalk.cyan(libraryName)}".`
+          )
+        );
+        console.log();
+        console.log(
+          `Fallback to ${chalk.cyan(
+            fallbackLibraryVersion
+          )}, please upgrade the dependency after generating the app.`
+        );
+        console.log();
+
+        return [
+          new inquirer.Separator('Available versions'),
+          fallbackLibraryVersion,
+        ];
+      }
+    },
+  },
 ].filter(question => isQuestionAsked({ question, args: optionsFromArguments }));
 
 const appName = path.basename(appPath);
@@ -127,6 +169,17 @@ try {
   process.exit(1);
 }
 
+async function getDefaultLibraryVersion(libraryName) {
+  try {
+    const versions = await fetchLibraryVersions(libraryName);
+    const latestStableVersion = latestSemver(versions);
+
+    return latestStableVersion;
+  } catch (err) {
+    return fallbackLibraryVersion;
+  }
+}
+
 (async function() {
   console.log(`Creating a new InstantSearch app in ${chalk.green(cdPath)}.`);
   console.log();
@@ -138,9 +191,9 @@ try {
     ...answers,
     appName,
     appPath,
-    template: answers.template,
-    instantsearchVersion: getLatestInstantSearchVersion(),
-    mainAttribute: answers.mainAttribute,
+    libraryVersion:
+      answers.libraryVersion ||
+      (await getDefaultLibraryVersion(getLibraryName(answers.template))),
   };
 
   await buildApp(config);

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,6 +77,10 @@ function isQuestionAsked({ question, args }) {
   return true;
 }
 
+function getLibraryName(name) {
+  return name.toLowerCase().replace(/ /g, '-');
+}
+
 function isYarnAvailable() {
   try {
     execSync('yarnpkg --version', { stdio: 'ignore' });
@@ -86,17 +90,12 @@ function isYarnAvailable() {
   }
 }
 
-function getLatestInstantSearchVersion() {
-  // TODO: get from a template package.json
-  return '2.7.0';
-}
-
 module.exports = {
   checkAppName,
   checkAppPath,
   getOptionsFromArguments,
   isQuestionAsked,
   isYarnAvailable,
-  getLatestInstantSearchVersion,
   camelCase,
+  getLibraryName,
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -187,3 +187,25 @@ describe('camelCase', () => {
     expect(utils.camelCase('instant-search-js')).toBe('instantSearchJs');
   });
 });
+
+describe('getLibraryName', () => {
+  test('InstantSearch.js', () => {
+    expect(utils.getLibraryName('InstantSearch.js')).toBe('instantsearch.js');
+  });
+
+  test('React InstantSearch', () => {
+    expect(utils.getLibraryName('React InstantSearch')).toBe(
+      'react-instantsearch'
+    );
+  });
+
+  test('Vue InstantSearch', () => {
+    expect(utils.getLibraryName('Vue InstantSearch')).toBe('vue-instantsearch');
+  });
+
+  test('Angular InstantSearch', () => {
+    expect(utils.getLibraryName('Angular InstantSearch')).toBe(
+      'angular-instantsearch'
+    );
+  });
+});

--- a/tasks/fetchLibraryVersions.js
+++ b/tasks/fetchLibraryVersions.js
@@ -1,0 +1,16 @@
+const algoliasearch = require('algoliasearch');
+
+const algoliaConfig = {
+  appId: 'OFCNCOG2CU',
+  apiKey: 'f54e21fa3a2a0160595bb058179bfb1e',
+  indexName: 'npm-search',
+};
+
+const client = algoliasearch(algoliaConfig.appId, algoliaConfig.apiKey);
+const index = client.initIndex(algoliaConfig.indexName);
+
+module.exports = async function fetchLibraryVersions(libraryName) {
+  const library = await index.getObject(libraryName);
+
+  return Object.keys(library.versions).reverse();
+};

--- a/templates/InstantSearch.js/index.html.hbs
+++ b/templates/InstantSearch.js/index.html.hbs
@@ -9,8 +9,8 @@
   <link rel="manifest" href="./manifest.webmanifest">
   <link rel="shortcut icon" href="./favicon.png">
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.js@{{instantsearchVersion}}/dist/instantsearch.min.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.js@{{instantsearchVersion}}/dist/instantsearch-theme-algolia.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.js@{{libraryVersion}}/dist/instantsearch.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.js@{{libraryVersion}}/dist/instantsearch-theme-algolia.min.css">
   <link rel="stylesheet" href="./src/app.css">
 
   <title>{{appName}}</title>
@@ -35,7 +35,7 @@
     <div id="pagination"></div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@{{instantsearchVersion}}/dist/instantsearch.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@{{libraryVersion}}/dist/instantsearch.min.js"></script>
   <script src="./src/app.js"></script>
 </body>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,6 +124,10 @@ acorn@^5.0.0, acorn@^5.3.0, acorn@^5.5.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
+agentkeepalive@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-2.2.0.tgz#c5d1bd4b129008f1163f236f86e5faea2026e2ef"
+
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -136,6 +140,26 @@ ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+algoliasearch@^3.27.1:
+  version "3.27.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.27.1.tgz#e1af42b97dbf44a2dd3a8c907be99c0c34e48414"
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.8"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -947,6 +971,10 @@ dom-serializer@0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
 domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
@@ -988,6 +1016,13 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+envify@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/envify/-/envify-4.1.0.tgz#f39ad3db9d6801b4e6b478b61028d3f0b6819f7e"
+  dependencies:
+    esprima "^4.0.0"
+    through "~2.3.4"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -1011,6 +1046,10 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+es6-promise@^4.1.0:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1171,6 +1210,10 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+events@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
 exec-sh@^0.2.0:
   version "0.2.1"
@@ -1493,6 +1536,13 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
 
 globals@^11.0.1, globals@^11.1.0:
   version "11.5.0"
@@ -1966,6 +2016,10 @@ is@^3.1.0:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isarray@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.4.tgz#38e7bcbb0f3ba1b7933c86ba1894ddfc3781bbb7"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2467,6 +2521,12 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+latest-semver@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/latest-semver/-/latest-semver-1.0.0.tgz#30a937f60787ae2450bdc07cbbff8436ce1946a2"
+  dependencies:
+    to-semver "^1.0.0"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -2510,6 +2570,10 @@ load-json-file@^2.0.0:
     parse-json "^2.2.0"
     pify "^2.0.0"
     strip-bom "^3.0.0"
+
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -2659,6 +2723,12 @@ mime-types@^2.1.12, mime-types@~2.1.17:
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
 
 minimatch@3.0.3, minimatch@^3.0.0:
   version "3.0.3"
@@ -2860,7 +2930,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.8:
+object-keys@^1.0.11, object-keys@^1.0.8, object-keys@~1.0.0:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
@@ -3095,6 +3165,10 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
@@ -3120,6 +3194,10 @@ punycode@^2.1.0:
 qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+
+querystring-es3@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -3190,6 +3268,12 @@ recursive-readdir@^2.1.0:
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
   dependencies:
     minimatch "3.0.3"
+
+reduce@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/reduce/-/reduce-1.0.1.tgz#14fa2e5ff1fc560703a020cbb5fbaab691565804"
+  dependencies:
+    object-keys "~1.0.0"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -3405,7 +3489,7 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -3725,7 +3809,7 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
-through@^2.3.6:
+through@^2.3.6, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -3778,6 +3862,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+to-semver@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/to-semver/-/to-semver-1.1.0.tgz#870902e1a5cac67ee30333d060022b3248a2604b"
+  dependencies:
+    semver "^5.3.0"
 
 toml@^2.3.2:
   version "2.3.2"


### PR DESCRIPTION
This PR adds support for the `libraryVersion` option which allows the user to select a specific version of the InstantSearch flavor used.

## Why

This feature allows us to reproduce reported bugs more easily by choosing a specific InstantSearch version for the app.

## How

I used the `npm-search` index to get all versions of the selected flavor, and get the latest stable version with [latest-semver](https://github.com/sindresorhus/latest-semver) (which is the default version of any app created).

## Preview

### Success

![Preview - Success](https://user-images.githubusercontent.com/6137112/39828027-ec19828a-53b9-11e8-9a5e-6a92a731ab58.gif)


### Failure

Happens when offline for instance (`AlgoliaSearchNetworkError` might be raised).

![Preview - Failure](https://user-images.githubusercontent.com/6137112/39828029-eedbeb84-53b9-11e8-92c0-a424a300e7c0.gif)



The fallback strategy is to install the version `1.0.0`, which is not great. Any idea to improve this fallback strategy?