### PR TITLE
feat(cli): Recommend attributes to display in hits

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -89,26 +89,6 @@ const optionsFromArguments = getOptionsFromArguments(options.rawArgs);
 
 const questions = [
   {
-    type: 'input',
-    name: 'appId',
-    message: 'Application ID',
-  },
-  {
-    type: 'input',
-    name: 'apiKey',
-    message: 'Search API key',
-  },
-  {
-    type: 'input',
-    name: 'indexName',
-    message: 'Index name',
-  },
-  {
-    type: 'input',
-    name: 'mainAttribute',
-    message: 'Main searchable attribute',
-  },
-  {
     type: 'list',
     name: 'template',
     message: 'InstantSearch template',
@@ -159,6 +139,21 @@ const questions = [
         ];
       }
     },
+  },
+  {
+    type: 'input',
+    name: 'appId',
+    message: 'Application ID',
+  },
+  {
+    type: 'input',
+    name: 'apiKey',
+    message: 'Search API key',
+  },
+  {
+    type: 'input',
+    name: 'indexName',
+    message: 'Index name',
   },
 ].filter(question => isQuestionAsked({ question, args: optionsFromArguments }));
 


### PR DESCRIPTION
This PR reorders the questions in the CLI and prints recommended attributes to display in the hits.

These recommended attributes are based on the highlightable attributes in the dashboard, gotten with a search on the index. They default to a selection among `['title', 'name', 'description']`. These values are bumped up in the ranking of the list since they are the most commonly used.

If there's a missing information to target the index (`appId`, `apiKey` or `indexName`), we skip the question. If the index is not reachable, we print the default list.

## Preview

![Preview](https://user-images.githubusercontent.com/6137112/41295368-b94c3224-6e5a-11e8-91e3-b9ca384e385b.gif)

---

Closes #32
