### PR TITLE
docs(readme): Use `npx` instead of `npm init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@
 > The tool requires Node ≥ 8.
 
 ```
-npm init instantsearch-app my-app
+npx create-instantsearch-app my-app
 cd my-app
 npm start
 ```
+
+> [`npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) is a tool introduced in `npm@5.2.0` that makes it possible to run CLI tools hosted on the npm registry.
 
 Open http://localhost:3000 to see you app.
 


### PR DESCRIPTION
We claim to support Node 8 but `npm init <package>` is not supported from this version.