### PR TITLE
fix(cli): fallback on latest version when stable unavailable

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -109,7 +109,7 @@ const questions = [
 
       try {
         const versions = await fetchLibraryVersions(libraryName);
-        const latestStableVersion = latestSemver(versions);
+        const latestStableVersion = latestSemver(versions) || versions[0];
 
         return [
           new inquirer.Separator('Latest stable version (recommended)'),

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -109,7 +109,11 @@ const questions = [
 
       try {
         const versions = await fetchLibraryVersions(libraryName);
-        const latestStableVersion = latestSemver(versions) || versions[0];
+        const latestStableVersion = latestSemver(versions);
+
+        if (!latestStableVersion) {
+          return versions;
+        }
 
         return [
           new inquirer.Separator('Latest stable version (recommended)'),


### PR DESCRIPTION
When the stable version is not available (only beta version are published) the script fail. In case we don't have a stable version fallback to the latest one.

**Before**

![screen shot 2018-06-13 at 15 17 20](https://user-images.githubusercontent.com/6513513/41353592-f9afd5a6-6f1c-11e8-8990-476db2fa60ca.png)

**After**

![screen shot 2018-06-13 at 15 17 47](https://user-images.githubusercontent.com/6513513/41353597-fca1df7a-6f1c-11e8-86c9-d06ac577aeef.png)