### PR TITLE
feat(templates): Warn facets usage with React Native template

### DIFF
--- a/templates/React InstantSearch Native/.template.js
+++ b/templates/React InstantSearch Native/.template.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const install = require('../../packages/tasks/node/install');
 const teardown = require('../../packages/tasks/node/teardown');
 
@@ -5,8 +6,27 @@ module.exports = {
   libraryName: 'react-instantsearch-native',
   templateName: 'react-instantsearch-native',
   appName: 'react-instantsearch-native-app',
-  keywords: ['algolia', 'instantSearch', 'react', 'react-native', 'react-instantsearch-native'],
+  keywords: [
+    'algolia',
+    'instantSearch',
+    'react',
+    'react-native',
+    'react-instantsearch-native',
+  ],
   tasks: {
+    setup(config) {
+      if (!config.silent && config.attributesForFaceting) {
+        console.log();
+        console.log(
+          `⚠️   The ${chalk.cyan(
+            'attributesForFaceting'
+          )} option is not supported in this template.`
+        );
+        console.log();
+      }
+
+      return Promise.resolve();
+    },
     install,
     teardown,
   },


### PR DESCRIPTION
Since `attributesForFaceting` is not supported by the React Native template, warn the user about it.

![Preview](https://user-images.githubusercontent.com/6137112/41423055-a58b133a-6ffa-11e8-829f-7970d7a8d844.png)
