### PR TITLE
fix(cli): use latest version when stable unavailable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log*
 
 # release
 /build
+/sample

--- a/src/cli/__tests__/getConfiguration.test.js
+++ b/src/cli/__tests__/getConfiguration.test.js
@@ -1,5 +1,11 @@
 const path = require('path');
+const utils = require('../../utils');
 const getConfiguration = require('../getConfiguration');
+
+jest.mock('../../utils', () => ({
+  ...require.requireActual('../../utils'),
+  fetchLibraryVersions: jest.fn(() => Promise.resolve(['1.0.0'])),
+}));
 
 test('without template throws', async () => {
   expect.assertions(1);
@@ -40,6 +46,20 @@ test('with options from arguments and prompt merge', async () => {
       libraryVersion: '1.0.0',
     })
   );
+});
+
+test('without stable version available', async () => {
+  utils.fetchLibraryVersions.mockImplementationOnce(() =>
+    Promise.resolve(['1.0.0-beta.0'])
+  );
+
+  const configuration = await getConfiguration({
+    answers: {
+      template: 'InstantSearch.js',
+    },
+  });
+
+  expect(configuration.libraryVersion).toBe('1.0.0-beta.0');
 });
 
 test('with config file overrides all options', async () => {

--- a/src/cli/getConfiguration.js
+++ b/src/cli/getConfiguration.js
@@ -28,7 +28,12 @@ module.exports = async function getConfiguration({
 
     libraryVersion = await fetchLibraryVersions(
       templateConfig.libraryName
-    ).then(latestSemver);
+    ).then(
+      versions =>
+        // Return the lastest available version when
+        // the stable version is not available
+        latestSemver(versions) || versions[0]
+    );
   }
 
   return {


### PR DESCRIPTION
**Summary**

When we provide a template directly from the CLI we don't let the user choose the version. By default we pick the latest `stable` version available. When there is no `stable` available Yarn will ask for which version you want to install but the template is generated with an empty version. 

This PR fix this issue by taking the latest version available in case the latest `stable` is not available. I also added the folder `sample` to the `.gitignore` to test the CLI with this folder name. We can test the template generation without pollute the git diff.

**Before**:

```json
{
  "dependencies": {
    "react-instantsearch-native": "^"
  }
}
```

**After**:

```json
{
  "dependencies": {
    "react-instantsearch-native": "^5.2.0-beta.1"
  }
}
```