### PR TITLE
refactor(tasks): Simplify teardown task for iOS

### DIFF
--- a/src/tasks/ios/teardown.js
+++ b/src/tasks/ios/teardown.js
@@ -2,28 +2,19 @@ const chalk = require('chalk');
 
 module.exports = function teardown(config) {
   if (!config.silent) {
-    try {
-      console.log();
-      console.log(
-        `🎉  Created ${chalk.bold.cyan(config.name)} at ${chalk.green(
-          config.path
-        )}.`
-      );
-      console.log();
+    console.log();
+    console.log(
+      `🎉  Created ${chalk.bold.cyan(config.name)} at ${chalk.green(
+        config.path
+      )}.`
+    );
+    console.log();
 
-      console.log(
-        `Begin by opening the workspace \`${chalk.green('App.xcworkspace')}\`.`
-      );
-      console.log();
-      console.log('⚡️  Start building something awesome!');
-    } catch (err) {
-      console.log();
-      console.error(chalk.red('🛑  The app generation failed.'));
-      console.error(err);
-      console.log();
-
-      return Promise.reject(err);
-    }
+    console.log(
+      `Begin by opening the workspace \`${chalk.green('App.xcworkspace')}\`.`
+    );
+    console.log();
+    console.log('⚡️  Start building something awesome!');
   }
 
   return Promise.resolve();


### PR DESCRIPTION
There's no need to `try/catch` since nothing can fail during this task (originally taken from [Node's teardown task](https://github.com/algolia/create-instantsearch-app/blob/6e27ec3cb525696fe5646ac9d03f87b3eac702d5/src/tasks/node/teardown.js)).