### PR TITLE
fix(ios): run pod repo update before install

### DIFF
--- a/src/tasks/ios/install.js
+++ b/src/tasks/ios/install.js
@@ -4,6 +4,9 @@ const chalk = require('chalk');
 module.exports = function install(config) {
   const logger = config.silent ? { log() {}, error() {} } : console;
   const initialDirectory = process.cwd();
+  const execSyncOptions = {
+    stdio: config.silent ? 'ignore' : 'inherit',
+  };
 
   logger.log();
   logger.log('📦  Installing dependencies...');
@@ -12,9 +15,8 @@ module.exports = function install(config) {
   process.chdir(config.path);
 
   try {
-    execSync('pod install', {
-      stdio: config.silent ? 'ignore' : 'inherit',
-    });
+    execSync('pod repo update', execSyncOptions);
+    execSync('pod install', execSyncOptions);
   } catch (err) {
     logger.log();
     logger.log();


### PR DESCRIPTION
**Summary**

In case it's your first install of CocoaPods (like me) the command will fail. We can run the command (see below) before each install.

```sh
pod repo update
```

Is it a problem @spinach?