### PR TITLE
feat(cli):  Add template categories

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -13,6 +13,7 @@ const {
   getAppTemplateConfig,
   fetchLibraryVersions,
   getAllTemplates,
+  getTemplatesByCategory,
   getTemplatePath,
 } = require('../utils');
 const getOptionsFromArguments = require('./getOptionsFromArguments');
@@ -89,9 +90,23 @@ try {
 const questions = [
   {
     type: 'list',
+    pageSize: 10,
     name: 'template',
     message: 'InstantSearch template',
-    choices: getAllTemplates(),
+    choices: () => {
+      const templatesByCategory = getTemplatesByCategory();
+      const choices = [];
+
+      for (const [category, values] of Object.entries(templatesByCategory)) {
+        choices.push(new inquirer.Separator(category));
+
+        for (const template of values) {
+          choices.push(template);
+        }
+      }
+
+      return choices;
+    },
     validate(input) {
       return Boolean(input);
     },

--- a/src/templates/Angular InstantSearch/.template.js
+++ b/src/templates/Angular InstantSearch/.template.js
@@ -2,6 +2,7 @@ const install = require('../../tasks/node/install');
 const teardown = require('../../tasks/node/teardown');
 
 module.exports = {
+  category: 'Web',
   libraryName: 'angular-instantsearch',
   templateName: 'angular-instantsearch',
   appName: 'angular-instantsearch-app',

--- a/src/templates/InstantSearch Android/.template.js
+++ b/src/templates/InstantSearch Android/.template.js
@@ -3,6 +3,7 @@ const install = require('../../tasks/ios/install');
 const teardown = require('../../tasks/android/teardown');
 
 module.exports = {
+  category: 'Mobile',
   templateName: 'instantsearch-android',
   appName: 'instantsearch-android-app',
   tasks: {

--- a/src/templates/InstantSearch iOS/.template.js
+++ b/src/templates/InstantSearch iOS/.template.js
@@ -3,6 +3,7 @@ const install = require('../../tasks/ios/install');
 const teardown = require('../../tasks/ios/teardown');
 
 module.exports = {
+  category: 'Mobile',
   templateName: 'instantsearch-ios',
   appName: 'instantsearch-ios-app',
   tasks: {

--- a/src/templates/InstantSearch.js/.template.js
+++ b/src/templates/InstantSearch.js/.template.js
@@ -2,6 +2,7 @@ const install = require('../../tasks/node/install');
 const teardown = require('../../tasks/node/teardown');
 
 module.exports = {
+  category: 'Web',
   libraryName: 'instantsearch.js',
   templateName: 'instantsearch.js',
   appName: 'instantsearch.js-app',

--- a/src/templates/React InstantSearch Native/.template.js
+++ b/src/templates/React InstantSearch Native/.template.js
@@ -3,6 +3,7 @@ const install = require('../../tasks/node/install');
 const teardown = require('../../tasks/node/teardown');
 
 module.exports = {
+  category: 'Mobile',
   libraryName: 'react-instantsearch-native',
   templateName: 'react-instantsearch-native',
   appName: 'react-instantsearch-native-app',

--- a/src/templates/React InstantSearch/.template.js
+++ b/src/templates/React InstantSearch/.template.js
@@ -2,6 +2,7 @@ const install = require('../../tasks/node/install');
 const teardown = require('../../tasks/node/teardown');
 
 module.exports = {
+  category: 'Web',
   libraryName: 'react-instantsearch-dom',
   templateName: 'react-instantsearch',
   appName: 'react-instantsearch-app',

--- a/src/templates/Vue InstantSearch/.template.js
+++ b/src/templates/Vue InstantSearch/.template.js
@@ -2,6 +2,7 @@ const install = require('../../tasks/node/install');
 const teardown = require('../../tasks/node/teardown');
 
 module.exports = {
+  category: 'Web',
   libraryName: 'vue-instantsearch',
   templateName: 'vue-instantsearch',
   appName: 'vue-instantsearch-app',

--- a/src/utils/__tests__/index.test.js
+++ b/src/utils/__tests__/index.test.js
@@ -85,3 +85,39 @@ describe('checkTemplateConfigFile', () => {
     }).not.toThrow();
   });
 });
+
+describe('getTemplatesByCategory', () => {
+  beforeAll(() => {
+    mockReaddirSync.mockImplementation(() => [
+      'InstantSearch.js',
+      'Angular InstantSearch',
+      'React InstantSearch',
+      'Vue InstantSearch',
+      'React InstantSearch Native',
+      'InstantSearch iOS',
+      'InstantSearch Android',
+    ]);
+    mockLstatSync.mockImplementation(() => ({ isDirectory: () => true }));
+  });
+
+  test('return the correct templates and categories', () => {
+    expect(utils.getTemplatesByCategory()).toEqual({
+      Web: expect.arrayContaining([
+        'InstantSearch.js',
+        'Angular InstantSearch',
+        'React InstantSearch',
+        'Vue InstantSearch',
+      ]),
+      Mobile: expect.arrayContaining([
+        'React InstantSearch Native',
+        'InstantSearch iOS',
+        'InstantSearch Android',
+      ]),
+    });
+  });
+
+  afterAll(() => {
+    mockReaddirSync.mockReset();
+    mockLstatSync.mockReset();
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -88,6 +88,30 @@ function getAllTemplates() {
   return templates;
 }
 
+function getTemplatesByCategory() {
+  const templatePaths = fs
+    .readdirSync(TEMPLATES_FOLDER)
+    .map(name => path.join(TEMPLATES_FOLDER, name))
+    .filter(source => fs.lstatSync(source).isDirectory());
+
+  const templates = templatePaths.reduce((allTemplates, source) => {
+    const name = path.basename(source);
+
+    const { category } = require(`${source}/.template.js`);
+
+    if (!category) {
+      return allTemplates;
+    }
+
+    const newAllTemplates = allTemplates;
+    newAllTemplates[category] = [...(newAllTemplates[category] || []), name];
+
+    return newAllTemplates;
+  }, {});
+
+  return templates;
+}
+
 function getTemplatePath(templateName) {
   const supportedTemplates = getAllTemplates();
 
@@ -114,4 +138,5 @@ module.exports = {
   fetchLibraryVersions,
   getAllTemplates,
   getTemplatePath,
+  getTemplatesByCategory,
 };


### PR DESCRIPTION
This PR adds categories to templates.

## Why

### 1. Order the templates

As we're getting more templates, I think it's better to distinguish web templates from mobiles templates. See if `Web` and `Native` make more sense than `Web` and `Mobile`.

### 2. Hide templates from the CLI

Templates having no `category` in their `.template.js` file don't show up in the CLI. This is a way to hide them but to still compile them to the `templates` branch for CodeSandbox (for the client, helper and AutoComplete.js templates).

## Preview

![image](https://user-images.githubusercontent.com/6137112/42315441-bb34a234-8047-11e8-97c1-ebc805763827.png)
