### PR TITLE
feat(templates): use searchClient in React

### DIFF
--- a/scripts/__snapshots__/e2e-templates.test.js.snap
+++ b/scripts/__snapshots__/e2e-templates.test.js.snap
@@ -3761,6 +3761,7 @@ exports[`Templates React InstantSearch File content: src/App.css 1`] = `
 
 exports[`Templates React InstantSearch File content: src/App.js 1`] = `
 "import React, { Component } from 'react';
+import algoliasearch from 'algoliasearch/lite';
 import {
   InstantSearch,
   Hits,
@@ -3771,6 +3772,11 @@ import {
 } from 'react-instantsearch-dom';
 import PropTypes from 'prop-types';
 import './App.css';
+
+const searchClient = algoliasearch(
+ 'appId',
+ 'apiKey'
+);
 
 class App extends Component {
   render() {
@@ -3789,11 +3795,7 @@ class App extends Component {
         </header>
 
         <div className=\\"container\\">
-          <InstantSearch
-            appId=\\"appId\\"
-            apiKey=\\"apiKey\\"
-            indexName=\\"indexName\\"
-          >
+          <InstantSearch searchClient={searchClient} indexName=\\"indexName\\">
             <div className=\\"search-panel\\">
               <div className=\\"search-panel__filters\\">
                 <RefinementList attribute=\\"facet1\\" />

--- a/src/templates/React InstantSearch/package.json
+++ b/src/templates/React InstantSearch/package.json
@@ -9,6 +9,7 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
+    "algoliasearch": "3.29.0",
     "react": "16.4.1",
     "react-dom": "16.4.1",
     "react-instantsearch-dom": "{{libraryVersion}}",

--- a/src/templates/React InstantSearch/src/App.js.hbs
+++ b/src/templates/React InstantSearch/src/App.js.hbs
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import algoliasearch from 'algoliasearch/lite';
 import {
   InstantSearch,
   Hits,
@@ -13,6 +14,11 @@ import {
 } from 'react-instantsearch-dom';
 import PropTypes from 'prop-types';
 import './App.css';
+
+const searchClient = algoliasearch(
+ '{{appId}}',
+ '{{apiKey}}'
+);
 
 class App extends Component {
   render() {
@@ -31,11 +37,7 @@ class App extends Component {
         </header>
 
         <div className="container">
-          <InstantSearch
-            appId="{{appId}}"
-            apiKey="{{apiKey}}"
-            indexName="{{indexName}}"
-          >
+          <InstantSearch searchClient={searchClient} indexName="{{indexName}}">
             <div className="search-panel">
               {{#if attributesForFaceting}}
               <div className="search-panel__filters">


### PR DESCRIPTION
Now that we are using `react-instantsearch-dom` we can use by default the `searchClient`. The prop is available since the version `5.1.0` and the first version of the package is `5.2.0`. No changes are required for React InstantSearch Native because the current version already use the `searchClient`.