### PR TITLE
fix(templates): Fix default failing tests in Angular

### DIFF
--- a/scripts/__snapshots__/e2e-templates.test.js.snap
+++ b/scripts/__snapshots__/e2e-templates.test.js.snap
@@ -359,15 +359,21 @@ exports[`Templates Angular InstantSearch File content: src/app/app.component.htm
 
 exports[`Templates Angular InstantSearch File content: src/app/app.component.spec.ts 1`] = `
 "import { TestBed, async } from '@angular/core/testing';
+import { NgAisModule } from 'angular-instantsearch';
 import { AppComponent } from './app.component';
+
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
         AppComponent
       ],
+      imports: [
+        NgAisModule.forRoot(),
+      ],
     }).compileComponents();
   }));
+
   it('should create the app', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
@@ -378,7 +384,7 @@ describe('AppComponent', () => {
 
 exports[`Templates Angular InstantSearch File content: src/app/app.component.ts 1`] = `
 "import { Component } from '@angular/core';
-import * as algoliasearch from \\"algoliasearch\\";
+import * as algoliasearch from 'algoliasearch';
 
 @Component({
   selector: 'app-root',

--- a/src/templates/Angular InstantSearch/src/app/app.component.spec.ts
+++ b/src/templates/Angular InstantSearch/src/app/app.component.spec.ts
@@ -1,13 +1,19 @@
 import { TestBed, async } from '@angular/core/testing';
+import { NgAisModule } from 'angular-instantsearch';
 import { AppComponent } from './app.component';
+
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
         AppComponent
       ],
+      imports: [
+        NgAisModule.forRoot(),
+      ],
     }).compileComponents();
   }));
+
   it('should create the app', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;


### PR DESCRIPTION
Default tests were previously failing because Angular didn't know the InstantSearch components.