### PR TITLE
ci(travis): Allow E2E tests to take up to 20 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
 env:
   matrix:
   - SCRIPT="yarn test && yarn lint"
-  - SCRIPT="yarn test:e2e"
+  - SCRIPT="travis_wait 20 yarn test:e2e"


### PR DESCRIPTION
Travis failed because its default limit is 10 minutes. The end-to-end tests take more time now because we test all templates' installation and build.

See: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received