### PR TITLE
docs: Add tutorials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,30 @@
 
 Thank you for wanting to get involved in Create InstantSearch App! The goal of the package is to enable users to create InstantSearch applications quickly.
 
+<details>
+  <summary><strong>Contents</strong></summary>
+
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Core concepts](#core-concepts)
+  - [Folder structure](#folder-structure)
+  - [Adding a template](#adding-a-template)
+- [Requirements](#requirements)
+- [Conventions](#conventions)
+  - [Commits](#commits)
+- [Workflow](#workflow)
+  - [Filing issues](#filing-issues)
+  - [Contributing to the code](#contributing-to-the-code)
+  - [Releasing](#releasing)
+  - [Updating templates on CodeSandbox](#updating-templates-on-codesandbox)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+</details>
+
 ## Core concepts
 
 The `create-instantsearch-app` CLI is based on the module `createInstantSearchApp(path, options?, tasks?)`.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@
 - [Get started](#get-started)
 - [Usage](#usage)
 - [API](#api)
-  - [Lifecycle](#lifecycle)
-  - [Templates](#templates)
 - [Tutorials](#tutorials)
 - [Previews](#previews)
 - [License](#license)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ create-instantsearch-app my-app --config config.json
 
 ## API
 
-`create-instantsearch-app` is based on the module `createInstantSearchApp(path, options?)`.
+`create-instantsearch-app` is based on the module `createInstantSearchApp(path, options?)`. The same [camel cased](https://en.wikipedia.org/wiki/Camel_case) options as the CLI are available.
 
 ```javascript
 const createInstantSearchApp = require('create-instantsearch-app');

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <details>
-  <summary><strong>Table of contents</strong></summary>
+  <summary><strong>Contents</strong></summary>
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -23,6 +23,7 @@
 - [API](#api)
   - [Lifecycle](#lifecycle)
   - [Templates](#templates)
+- [Tutorials](#tutorials)
 - [Previews](#previews)
 - [License](#license)
 
@@ -93,13 +94,13 @@ Supported templates are:
 create-instantsearch-app my-app --template "React InstantSearch"
 ```
 
-You can also [create your own template](#templates) and specify its path.
+You can also [create your own template](docs/custom-templates.md) and specify its path.
 
 #### `--config`
 
 The `config` flag is handy to automate app generations.
 
-<h6 align="center">`config.json`</h6>
+<h6 align="center">config.json</h6>
 
 ```json
 {
@@ -123,7 +124,7 @@ create-instantsearch-app my-app --config config.json
 
 ## API
 
-`create-instantsearch-app` is based on the module `createInstantSearchApp(path, options?, tasks?)`.
+`create-instantsearch-app` is based on the module `createInstantSearchApp(path, options?)`.
 
 ```javascript
 const createInstantSearchApp = require('create-instantsearch-app');
@@ -138,83 +139,10 @@ const app = createInstantSearchApp('~/lab/my-app', {
 app.create().then(() => console.log('App generated!'));
 ```
 
-### Lifecycle
+## Tutorials
 
-The app generation follows this lifecycle:
-
-![Lifecycle](https://user-images.githubusercontent.com/6137112/41421858-f838c2a6-6ff7-11e8-8cef-4cc07f1f4f44.png)
-
-<details>
-  <summary>Alternative text</summary>
-
-1.  **Setup**
-2.  **Build**
-3.  **Install**
-4.  (**Clean**) _if the installation fails_
-5.  **Teardown**
-
-</details>
-
-Each task can be plugged to the third argument of `createInstantSearchApp(path, options?, tasks?)` and is passed the configuration of the app.
-
-<h6 align="center">Tasks example</h6>
-
-```javascript
-const app = createInstantSearchApp(
-  'my-app',
-  { template: 'InstantSearch.js' },
-  {
-    setup(config) {
-      // Check the project requirements
-    },
-    teardown(config) {
-      // Go to the project folder
-    },
-  }
-);
-
-app.create();
-```
-
-### Templates
-
-To use your own template, create a file `.template.js` at the root of your template directory. This is the configuration file that `createInstantSearchApp()` reads to retrieve the version of the library to install from `npm` and the [lifecycle tasks](#lifecycle) to process.
-
-<h6 align="center">`.template.js`</h6>
-
-```javascript
-const { execSync } = require('child_process');
-
-module.exports = {
-  libraryName: 'algoliasearch-helper',
-  tasks: {
-    install(config) {
-      execSync(`cd ${config.path} && npm install`);
-    },
-    teardown(config) {
-      console.log('Begin by running: npm start');
-    },
-  },
-};
-```
-
-The template files support the [Handlebars](https://handlebarsjs.com) syntax to inject values passed to `create-instantsearch-app`. You can see examples in the [`templates`](templates) folder. Then, pass the path to your template when generating the app.
-
-Using the API:
-
-```javascript
-const app = createInstantSearchApp('my-app', {
-  template: './my-custom-template',
-});
-
-app.create();
-```
-
-Using the CLI:
-
-```
-create-instantsearch-app my-app --template ./my-custom-template
-```
+- [Creating a custom template](docs/custom-templates.md)
+- [Deploying an InstantSearch App](docs/deploy.md)
 
 ## Previews
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ yarn start
 
 ## Usage
 
-This package comes with the module `createInstantSearchApp(path, options?, tasks?)` and the command-line tool `create-instantsearch-app`.
+This package comes with the module `createInstantSearchApp(path, options?)` and the command-line tool `create-instantsearch-app`.
 
 ```
 $ create-instantsearch-app --help

--- a/docs/custom-templates.md
+++ b/docs/custom-templates.md
@@ -1,0 +1,161 @@
+# Creating a custom template
+
+Besides all the InstantSearch templates provided, the Create InstantSearch API enables you to create your own template.
+
+<details>
+  <summary><strong>Contents</strong></summary>
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Defining the template](#defining-the-template)
+  - [`libraryName`](#libraryname)
+  - [`tasks`](#tasks)
+- [Injecting values to the template](#injecting-values-to-the-template)
+- [Using the template](#using-the-template)
+- [Examples](#examples)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+</details>
+
+## Defining the template
+
+Once you've created a project directory, you can turn it into a template by adding a file `.template.js` at its root. This is the configuration file that drives `createInstantSearchApp()` to bootstrap your application.
+
+This definition file returns a object with several properties.
+
+<h6 align="center">.template.js</h6>
+
+```javascript
+const { execSync } = require('child_process');
+
+module.exports = {
+  libraryName: 'react-instantsearch',
+  tasks: {
+    install(config) {
+      execSync(`cd ${config.path} && npm install`);
+    },
+    teardown(config) {
+      console.log('Begin by running: npm start');
+    },
+  },
+};
+```
+
+### `libraryName`
+
+> `string` (optional) | no default
+
+The name of the [npm](https://www.npmjs.com) library to fetch versions for.
+
+### `tasks`
+
+> `object` | defaults as follows
+
+The tasks are hooks that define your [application generation lifecycle](#lifecycle). Each of these hooks are functions which receives the [app configuration](#configuration-object) as parameters. You can use this configuration to drive the application generation.
+
+#### `setup(config: object)`
+
+> No default
+
+Can be leveraged to check the project requirements.
+
+#### `build(config: object)`
+
+> Defaults to copying and injecting the values
+
+Can be leveraged to generate the project differently.
+
+#### `install(config: object)`
+
+> No default
+
+Can be leveraged to install dependencies with a package manager.
+
+#### `clean(config: object)`
+
+> Defaults to deleting the project which installation has failed
+
+Can be leveraged to warn the user that the installation has failed.
+
+#### `teardown(config: object)`
+
+> No default
+
+Can be leveraged to display instructions to run the app.
+
+<h6 align="center" id="lifecycle">Application generation lifeycle</h6>
+
+![Setup → Build → Install → Clean (if installation fails) → Teardown](https://user-images.githubusercontent.com/6137112/41421858-f838c2a6-6ff7-11e8-8cef-4cc07f1f4f44.png)
+
+<h6 align="center" id="configuration-object"><code>config</code> object</h6>
+
+```js
+{
+  name: 'app-name',
+  path: '/dev/app-name',
+  template: 'InstantSearch.js',
+  libraryVersion: '2.9.0',
+  appId: 'APP_ID',
+  apiKey: 'API_KEY',
+  indexName: 'INDEX_NAME',
+  attributesToDisplay: ['title', 'description'],
+  installation: true,
+  silent: false,
+}
+```
+
+## Injecting values to the template
+
+By default, the `build` task supports the [Handlebars](https://handlebarsjs.com) syntax to inject values passed to Create InstantSearch App. You can explicitely suffix the template files with `.hbs` or leave them as is (`.js` in this case).
+
+<h6 align="center">App.js.hbs</h6>
+
+```handlebars
+import React, { Component } from 'react';
+import algoliasearch from 'algoliasearch/lite';
+import {
+  InstantSearch,
+  Hits,
+  SearchBox,
+  {{#if attributesToDisplay}}
+  Highlight,
+  {{/if}}
+} from 'react-instantsearch-dom';
+
+const searchClient = algoliasearch(
+  '{{appId}}',
+  '{{apiKey}}'
+);
+
+<InstantSearch searchClient={searchClient} indexName="{{indexName}}">
+  <SearchBox placeholder="{{searchPlaceholder}}" />
+  {/* ... */}
+</InstantSearch>
+```
+
+## Using the template
+
+Create InstantSearch App reads your `.template.js` file and gets the specificed tasks in the provided template.
+
+Using the API:
+
+```javascript
+const app = createInstantSearchApp('my-app', {
+  template: '/path/to/my-custom-template',
+});
+
+app.create();
+```
+
+Using the CLI:
+
+```
+create-instantsearch-app my-app --template /path/to/my-custom-template
+```
+
+## Examples
+
+You can find all the officially supported templates in the [`src/templates/`](../src/templates) folder.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,44 @@
+# Deploy an InstantSearch app
+
+Create InstantSearch App generates applications that are ready to be deployed. They rely on bundlers and framework toolkits (Parcel, Create React App, Vue CLI, Angular CLI, etc.).
+
+Your app can be deployed in a single command, assuming you're located in its folder.
+
+<details>
+  <summary><strong>Contents</strong></summary>
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [CodeSandbox](#codesandbox)
+- [Surge](#surge)
+- [Now](#now)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+</details>
+
+## CodeSandbox
+
+```
+npx codesandbox .
+```
+
+[Learn more about CodeSandbox →](https://codesandbox.io)
+
+## Surge
+
+```
+npx surge
+```
+
+[Learn more about Surge →](https://surge.sh)
+
+## Now
+
+```
+npx now .
+```
+
+[Learn more Now →](https://zeit.co/now)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint .",
     "lint:fix": "yarn lint --fix",
     "format": "prettier --write *.{js,md,json}",
-    "doctoc": "doctoc --maxlevel 3 README.md",
+    "doctoc": "doctoc --maxlevel 3 README.md CONTRIBUTING.md docs/",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "release-templates": "node ./scripts/release-templates",
     "release": "release-it",


### PR DESCRIPTION
Add tutorials for:

- Creating a custom template
- Deploying an InstantSearch App

I decided to undocument `createInstantSearchApp(path, options?, tasks?)` in favor of `createInstantSearchApp(path, options?)` and creating custom templates directly.

Closes #152.