### PR TITLE
chore(jest): provide node environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
       "<rootDir>/src/templates/"
-    ]
+    ],
+    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
This way it does not load jsdom (which we don't use here). Also the latest jsdom generates security issues, but since we do not want jsdom for this project, we should not even be bothered.

https://github.com/facebook/jest/issues/6766