### PR TITLE
revert: fix(deps): update dependency react-native to v0.56.0 (#193)

### DIFF
--- a/src/templates/React InstantSearch Native/package.json
+++ b/src/templates/React InstantSearch Native/package.json
@@ -16,7 +16,7 @@
     "prop-types": "15.6.2",
     "react": "16.4.2",
     "react-instantsearch-native": "{{libraryVersion}}",
-    "react-native": "0.56.0"
+    "react-native": "0.55.4"
   },
   "devDependencies": {
     "eslint": "5.5.0",


### PR DESCRIPTION
This reverts commit 28266580c7b7395ae8cd959931e64c03b5efacad.

> Expo SDK v29.0.0 is once again based on React Native 0.55.4.

[See reference](https://blog.expo.io/expo-sdk-v29-0-0-is-now-available-f001d77fadf)