### PR TITLE
fix(templates): Add Vue ESLint config

### DIFF
--- a/scripts/__snapshots__/e2e-templates.test.js.snap
+++ b/scripts/__snapshots__/e2e-templates.test.js.snap
@@ -4411,16 +4411,22 @@ exports[`Templates Vue InstantSearch File content: src/App.vue 1`] = `
                 'ais-search-box__submit': 'ais-SearchBox-submit',
                 'ais-search-box__loading-indicator': 'ais-SearchBox-loadingIndicator',
               }\\"
-            ></ais-search-box>
+            />
 
             <ais-results class=\\"ais-Hits-list\\">
               <template slot-scope=\\"{ result }\\">
                 <article class=\\"ais-Hits-item\\">
                   <h1>
-                    <ais-highlight :result=\\"result\\" attribute-name=\\"attribute1\\"></ais-highlight>
+                    <ais-highlight
+                      :result=\\"result\\"
+                      attribute-name=\\"attribute1\\"
+                    />
                   </h1>
                   <p>
-                    <ais-highlight :result=\\"result\\" attribute-name=\\"attribute2\\"></ais-highlight>
+                    <ais-highlight
+                      :result=\\"result\\"
+                      attribute-name=\\"attribute2\\"
+                    />
                   </p>
                 </article>
               </template>
@@ -4438,7 +4444,7 @@ exports[`Templates Vue InstantSearch File content: src/App.vue 1`] = `
                   'ais-pagination__item--last': 'ais-Pagination-item--last',
                   'ais-pagination__link': 'ais-Pagination-link',
                 }\\"
-              ></ais-pagination>
+              />
             </div>
           </div>
         </div>
@@ -4529,6 +4535,7 @@ import InstantSearch from 'vue-instantsearch';
 
 Vue.use(InstantSearch);
 
+// eslint-disable-next-line no-new
 new Vue({
   el: '#app',
   render: h => h(App),

--- a/src/templates/Vue InstantSearch/package.json
+++ b/src/templates/Vue InstantSearch/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-html": "4.0.5",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-prettier": "2.6.2",
+    "eslint-plugin-vue": "4.7.1",
     "file-loader": "2.0.0",
     "prettier": "1.14.2",
     "vue-loader": "14.2.3",

--- a/src/templates/Vue InstantSearch/src/App.vue
+++ b/src/templates/Vue InstantSearch/src/App.vue
@@ -39,19 +39,25 @@
                 'ais-search-box__submit': 'ais-SearchBox-submit',
                 'ais-search-box__loading-indicator': 'ais-SearchBox-loadingIndicator',
               }"
-            ></ais-search-box>
+            />
 
             {{#if attributesToDisplay}}
             <ais-results class="ais-Hits-list">
               <template slot-scope="{ result }">
                 <article class="ais-Hits-item">
                   <h1>
-                    <ais-highlight :result="result" attribute-name="{{attributesToDisplay.[0]}}"></ais-highlight>
+                    <ais-highlight
+                      :result="result"
+                      attribute-name="{{attributesToDisplay.[0]}}"
+                    />
                   </h1>
                   {{#each attributesToDisplay}}
                   {{#unless @first}}
                   <p>
-                    <ais-highlight :result="result" attribute-name="{{this}}"></ais-highlight>
+                    <ais-highlight
+                      :result="result"
+                      attribute-name="{{this}}"
+                    />
                   </p>
                   {{/unless}}
                   {{/each}}
@@ -59,7 +65,7 @@
               </template>
             </ais-results>
             {{else}}
-            <ais-results class="ais-Hits-list"></ais-results>
+            <ais-results class="ais-Hits-list" />
             {{/if}}
 
             <div class="pagination">
@@ -74,7 +80,7 @@
                   'ais-pagination__item--last': 'ais-Pagination-item--last',
                   'ais-pagination__link': 'ais-Pagination-link',
                 }"
-              ></ais-pagination>
+              />
             </div>
           </div>
         </div>

--- a/src/templates/Vue InstantSearch/src/main.js
+++ b/src/templates/Vue InstantSearch/src/main.js
@@ -4,6 +4,7 @@ import InstantSearch from 'vue-instantsearch';
 
 Vue.use(InstantSearch);
 
+// eslint-disable-next-line no-new
 new Vue({
   el: '#app',
   render: h => h(App),


### PR DESCRIPTION
As spotted in #239, the Vue template needs `eslint-plugin-vue` to work correctly.

This PR also makes the template ESLint compliant.