### PR TITLE
fix(InstantSearch): disable autofocus

### DIFF
--- a/scripts/__snapshots__/e2e-templates.test.js.snap
+++ b/scripts/__snapshots__/e2e-templates.test.js.snap
@@ -2912,6 +2912,7 @@ const search = instantsearch({
 search.addWidget(
   instantsearch.widgets.searchBox({
     container: '#searchbox',
+    autofocus: false,
     placeholder: 'Search placeholder',
   })
 );

--- a/src/templates/InstantSearch.js/src/app.js.hbs
+++ b/src/templates/InstantSearch.js/src/app.js.hbs
@@ -9,6 +9,7 @@ const search = instantsearch({
 search.addWidget(
   instantsearch.widgets.searchBox({
     container: '#searchbox',
+    autofocus: false,
     {{#if searchPlaceholder}}
     placeholder: '{{searchPlaceholder}}',
     {{/if}}


### PR DESCRIPTION
This PR disable the `autofocus` option for InstantSearch. When you are working on an App or on CodeSandbox the SearchBox get the focus on each reload. It's a bit frustrating.