### PR TITLE
fix(angular template): Added prod param to ng build command

### DIFF
--- a/src/templates/Angular InstantSearch/package.json
+++ b/src/templates/Angular InstantSearch/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 3000",
-    "build": "ng build",
+    "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
I'd like to suggest to add the --prod param to the build command
This is how we build the example, and the result is much thinner.