### PR TITLE
feat(cli): add default Algolia credentials

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -169,11 +169,13 @@ const questions = [
     type: 'input',
     name: 'appId',
     message: 'Application ID',
+    default: 'latency',
   },
   {
     type: 'input',
     name: 'apiKey',
     message: 'Search API key',
+    default: '6be0576ff61c053d5f9a3225e2a90f76',
   },
   {
     type: 'input',

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -181,6 +181,7 @@ const questions = [
     type: 'input',
     name: 'indexName',
     message: 'Index name',
+    default: 'instant_search',
   },
   {
     type: 'checkbox',


### PR DESCRIPTION
Uses the [inquirer](https://www.npmjs.com/package/inquirer) default value feature

closes #290 