### PR TITLE
chore(changelog): don't generate whole changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:fix": "yarn lint --fix",
     "format": "prettier --write *.{js,md,json}",
     "doctoc": "doctoc --maxlevel 3 README.md CONTRIBUTING.md docs/",
-    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
+    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "release-templates": "node ./scripts/release-templates",
     "release": "release-it",
     "release:beta": "release-it --preRelease=beta"


### PR DESCRIPTION
The previous script generated all the changelog every time the command was run.