### PR TITLE
chore(tests): convert test names to string

### DIFF
--- a/scripts/e2e-installs.test.js
+++ b/scripts/e2e-installs.test.js
@@ -45,7 +45,7 @@ describe('Installation', () => {
       templates.forEach(templatePath => {
         const templateName = path.basename(templatePath);
 
-        describe(templateName, () => {
+        describe(`${templateName}`, () => {
           test('installs and builds correctly', () => {
             execSync(
               `yarn start ${appPath} \

--- a/scripts/e2e-templates.test.js
+++ b/scripts/e2e-templates.test.js
@@ -17,7 +17,7 @@ describe('Templates', () => {
     const templateName = path.basename(templatePath);
     const templateConfig = require(`${templatePath}/.template.js`);
 
-    describe(templateName, () => {
+    describe(`${templateName}`, () => {
       let temporaryDirectory;
       let appPath;
       let configFilePath;


### PR DESCRIPTION
ESLint's rule `jest/valid-describe` failed because some describe names were not recognized as strings.