### PR TITLE
fix(angular): use instantsearch.css styles directly

### DIFF
--- a/scripts/__snapshots__/e2e-templates.test.js.snap
+++ b/scripts/__snapshots__/e2e-templates.test.js.snap
@@ -58,8 +58,8 @@ exports[`Templates Angular InstantSearch File content: angular.json 1`] = `
               \\"src/assets\\"
             ],
             \\"styles\\": [
-              \\"node_modules/angular-instantsearch/bundles/instantsearch.min.css\\",
-              \\"node_modules/angular-instantsearch/bundles/instantsearch-theme-algolia.min.css\\",
+              \\"node_modules/instantsearch.css/themes/reset.css\\",
+              \\"node_modules/instantsearch.css/themes/algolia.css\\",
               \\"src/styles.css\\"
             ],
             \\"scripts\\": []

--- a/src/templates/Angular InstantSearch/angular.json
+++ b/src/templates/Angular InstantSearch/angular.json
@@ -23,8 +23,8 @@
               "src/assets"
             ],
             "styles": [
-              "node_modules/angular-instantsearch/bundles/instantsearch.min.css",
-              "node_modules/angular-instantsearch/bundles/instantsearch-theme-algolia.min.css",
+              "node_modules/instantsearch.css/themes/reset.css",
+              "node_modules/instantsearch.css/themes/algolia.css",
               "src/styles.css"
             ],
             "scripts": []


### PR DESCRIPTION
I found out about this while writing the customization guide for angular.
Right now it seems we don't adovcate for using `instantsearch.css` styles directly.

After this is merged, we'd need to release and regenerate the samples in https://github.com/algolia/doc-code-samples/tree/master/Angular%20InstantSearch