### PR TITLE
refactor(api): export configuration checker

### DIFF
--- a/src/api/check-config.js
+++ b/src/api/check-config.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const { checkAppName, checkAppPath } = require('../utils');
+
+function getOptions({ supportedTemplates }) {
+  return {
+    path: {
+      validate(input) {
+        // Side effect: `checkAppPath()` can throw
+        return Boolean(input) && checkAppPath(input);
+      },
+    },
+    name: {
+      validate(input) {
+        // Side effect: `checkAppName()` can throw
+        return checkAppName(input);
+      },
+    },
+    template: {
+      validate(input) {
+        return (
+          supportedTemplates.includes(input) ||
+          fs.existsSync(`${input}/.template.js`)
+        );
+      },
+      getErrorMessage() {
+        return `The template directory must contain a configuration file \`.template.js\` or must be one of those: ${supportedTemplates.join(
+          ', '
+        )}`;
+      },
+    },
+    installation: {
+      validate(input) {
+        return input === true || input === false;
+      },
+    },
+  };
+}
+
+module.exports = function checkConfig(config, { supportedTemplates }) {
+  const options = getOptions({ supportedTemplates });
+
+  Object.keys(options).forEach(optionName => {
+    const isOptionValid = options[optionName].validate(config[optionName]);
+
+    if (!isOptionValid) {
+      const errorMessage = options[optionName].getErrorMessage
+        ? options[optionName].getErrorMessage(config[optionName])
+        : `The option \`${optionName}\` is required.`;
+
+      throw new Error(errorMessage);
+    }
+  });
+};

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,58 +1,11 @@
-const fs = require('fs');
 const path = require('path');
+const checkConfig = require('./check-config');
 const resolveTemplate = require('./resolve-template');
 const buildTask = require('../tasks/common/build');
 const cleanTask = require('../tasks/common/clean');
-const { checkAppName, checkAppPath, getAllTemplates } = require('../utils');
+const { getAllTemplates } = require('../utils');
 
 const supportedTemplates = getAllTemplates();
-
-const OPTIONS = {
-  path: {
-    validate(input) {
-      // Side effect: `checkAppPath()` can throw
-      return Boolean(input) && checkAppPath(input);
-    },
-  },
-  name: {
-    validate(input) {
-      // Side effect: `checkAppName()` can throw
-      return checkAppName(input);
-    },
-  },
-  template: {
-    validate(input) {
-      return (
-        supportedTemplates.includes(input) ||
-        fs.existsSync(`${input}/.template.js`)
-      );
-    },
-    getErrorMessage() {
-      return `The template directory must contain a configuration file \`.template.js\` or must be one of those: ${supportedTemplates.join(
-        ', '
-      )}`;
-    },
-  },
-  installation: {
-    validate(input) {
-      return input === true || input === false;
-    },
-  },
-};
-
-function checkConfig(config) {
-  Object.keys(OPTIONS).forEach(optionName => {
-    const isOptionValid = OPTIONS[optionName].validate(config[optionName]);
-
-    if (!isOptionValid) {
-      const errorMessage = OPTIONS[optionName].getErrorMessage
-        ? OPTIONS[optionName].getErrorMessage(config[optionName])
-        : `The option \`${optionName}\` is required.`;
-
-      throw new Error(errorMessage);
-    }
-  });
-}
 
 function noop() {}
 
@@ -66,7 +19,7 @@ function createInstantSearchApp(appPath, options = {}, tasks = {}) {
     path: appPath ? path.resolve(appPath) : '',
   };
 
-  checkConfig(config);
+  checkConfig(config, { supportedTemplates });
 
   const {
     setup = noop,


### PR DESCRIPTION
This is a refactor that moves `checkConfig()` to its own file.