### PR TITLE
feat(api): throw when unsupported template version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "metalsmith-ignore": "1.0.0",
     "metalsmith-in-place": "4.2.0",
     "metalsmith-rename": "1.0.0",
+    "semver": "5.6.0",
     "validate-npm-package-name": "3.0.0"
   },
   "devDependencies": {

--- a/src/api/__tests__/resolve-template.test.js
+++ b/src/api/__tests__/resolve-template.test.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const resolveTemplate = require('../resolve-template');
 
-describe('resolve-template', () => {
-  test('with unknown template', () => {
+describe('resolveTemplate', () => {
+  test('selects the template with unknown template', () => {
     expect(
       resolveTemplate(
         {
@@ -15,7 +15,7 @@ describe('resolve-template', () => {
     ).toBe('../unknown-template');
   });
 
-  test('with known template', () => {
+  test('selects the default templatewith known template', () => {
     expect(
       resolveTemplate(
         {
@@ -28,7 +28,7 @@ describe('resolve-template', () => {
     ).toBe(path.resolve('src/templates/InstantSearch.js'));
   });
 
-  test('with InstantSearch.js 2 template', () => {
+  test('selects the right template with InstantSearch.js template and version 2', () => {
     expect(
       resolveTemplate(
         {
@@ -40,5 +40,21 @@ describe('resolve-template', () => {
         }
       )
     ).toBe(path.resolve('src/templates/InstantSearch.js 2'));
+  });
+
+  test('throws with unsupported version', () => {
+    expect(() =>
+      resolveTemplate(
+        {
+          template: 'InstantSearch.js',
+          libraryVersion: '1.0.0',
+        },
+        {
+          supportedTemplates: ['InstantSearch.js'],
+        }
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"The template \\"InstantSearch.js\\" does not support the version 1.0.0."`
+    );
   });
 });

--- a/src/api/resolve-template.js
+++ b/src/api/resolve-template.js
@@ -1,9 +1,11 @@
 const path = require('path');
+const semver = require('semver');
+const { getAppTemplateConfig } = require('../utils');
 
 function getTemplateNameByLibraryVersion(templateName, libraryVersion = '') {
   if (
     templateName === 'InstantSearch.js' &&
-    libraryVersion.substr(0, 2) === '2.'
+    semver.satisfies(libraryVersion, '>= 2.0.0 < 3.0.0')
   ) {
     return 'InstantSearch.js 2';
   }
@@ -16,6 +18,28 @@ module.exports = function resolveTemplate(options, { supportedTemplates }) {
     path.basename(options.template || ''),
     options.libraryVersion
   );
+  let supportedVersion;
+
+  try {
+    const templateConfig = getAppTemplateConfig(
+      path.resolve('src/templates', templateName)
+    );
+    supportedVersion = templateConfig.supportedVersion;
+  } catch (error) {
+    // The template doesn't provide a configuration file `.template.js`.
+  }
+
+  if (
+    supportedVersion &&
+    options.libraryVersion &&
+    !semver.satisfies(options.libraryVersion, supportedVersion)
+  ) {
+    throw new Error(
+      `The template "${path.basename(
+        options.template || ''
+      )}" does not support the version ${options.libraryVersion}.`
+    );
+  }
 
   return supportedTemplates.includes(templateName)
     ? path.resolve('src/templates', templateName)

--- a/src/templates/InstantSearch.js 2/.template.js
+++ b/src/templates/InstantSearch.js 2/.template.js
@@ -3,6 +3,7 @@ const teardown = require('../../tasks/node/teardown');
 
 module.exports = {
   libraryName: 'instantsearch.js',
+  supportedVersion: '>= 2.0.0 < 3.0.0',
   templateName: 'instantsearch.js',
   appName: 'instantsearch.js-app',
   keywords: ['algolia', 'InstantSearch', 'Vanilla', 'instantsearch.js'],

--- a/src/templates/InstantSearch.js/.template.js
+++ b/src/templates/InstantSearch.js/.template.js
@@ -4,6 +4,7 @@ const teardown = require('../../tasks/node/teardown');
 module.exports = {
   category: 'Web',
   libraryName: 'instantsearch.js',
+  supportedVersion: '>= 3.0.0 < 4.0.0',
   templateName: 'instantsearch.js',
   appName: 'instantsearch.js-app',
   keywords: ['algolia', 'InstantSearch', 'Vanilla', 'instantsearch.js'],

--- a/src/templates/Vue InstantSearch/.template.js
+++ b/src/templates/Vue InstantSearch/.template.js
@@ -4,6 +4,7 @@ const teardown = require('../../tasks/node/teardown');
 module.exports = {
   category: 'Web',
   libraryName: 'vue-instantsearch',
+  supportedVersion: '>= 1.0.0 < 2.0.0',
   templateName: 'vue-instantsearch',
   appName: 'vue-instantsearch-app',
   keywords: ['algolia', 'InstantSearch', 'Vue', 'vue-instantsearch'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5333,6 +5333,7 @@ semver@5.4.1:
 semver@5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
 semver@^5.5.1:
   version "5.5.1"


### PR DESCRIPTION
This adds detection for unsupported template versions.

It now supports the key `supportedVersion` in `.template.js` files which accepts a semver range. If this range is not supported, it throws before creating the application. This avoids creating a broken application when the user choses an old unsupported version.

The `supportedVersion` key was added for the templates: InstantSearch.js, InstantSearch.js 2, Vue InstantSearch.