### PR TITLE
fix(api): resolve relative paths

### DIFF
--- a/scripts/e2e-installs.test.js
+++ b/scripts/e2e-installs.test.js
@@ -106,6 +106,16 @@ describe('Installation', () => {
   });
 
   describe('Path', () => {
+    test('with relative paths does not throw', () => {
+      expect(() => {
+        execSync(
+          `yarn start ${appPath} \
+            --template "./src/templates/InstantSearch.js" \
+            --no-installation`
+        );
+      }).not.toThrow();
+    });
+
     test('without conflict generates files', () => {
       execSync(
         `yarn start ${appPath} \

--- a/src/api/check-config.js
+++ b/src/api/check-config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const fs = require('fs');
 const { checkAppName, checkAppPath } = require('../utils');
 
@@ -17,7 +18,7 @@ function getOptions({ supportedTemplates }) {
     },
     template: {
       validate(input) {
-        return fs.existsSync(`${input}/.template.js`);
+        return fs.existsSync(path.join(input || '', '.template.js'));
       },
       getErrorMessage() {
         return `The template directory must contain a configuration file \`.template.js\` or must be one of those: ${supportedTemplates.join(

--- a/src/api/check-config.js
+++ b/src/api/check-config.js
@@ -17,10 +17,7 @@ function getOptions({ supportedTemplates }) {
     },
     template: {
       validate(input) {
-        return (
-          supportedTemplates.includes(input) ||
-          fs.existsSync(`${input}/.template.js`)
-        );
+        return fs.existsSync(`${input}/.template.js`);
       },
       getErrorMessage() {
         return `The template directory must contain a configuration file \`.template.js\` or must be one of those: ${supportedTemplates.join(

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -61,7 +61,7 @@ function checkAppPath(appPath) {
 
 function getAppTemplateConfig(templatePath, { loadFileFn = require } = {}) {
   try {
-    return loadFileFn(path.resolve(`${templatePath}/.template.js`));
+    return loadFileFn(path.resolve(path.join(templatePath, '.template.js')));
   } catch (err) {
     throw new Error(
       `The template configuration file \`.template.js\` contains errors:

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -61,7 +61,7 @@ function checkAppPath(appPath) {
 
 function getAppTemplateConfig(templatePath, { loadFileFn = require } = {}) {
   try {
-    return loadFileFn(`${templatePath}/.template.js`);
+    return loadFileFn(path.resolve(`${templatePath}/.template.js`));
   } catch (err) {
     throw new Error(
       `The template configuration file \`.template.js\` contains errors:


### PR DESCRIPTION
The template paths are given with relative paths to the API, so adding `path.resolve` makes sure that the path becomes absolute and exists.

I added an end-to-end test with a relative path to make sure it's resolved.

This should close #364.