### PR TITLE
fix(templates): use expo for react-native

### DIFF
--- a/scripts/__snapshots__/e2e-templates.test.js.snap
+++ b/scripts/__snapshots__/e2e-templates.test.js.snap
@@ -4259,17 +4259,6 @@ Array [
 ]
 `;
 
-exports[`Templates React InstantSearch Native File content: .babelrc 1`] = `
-"{
-  \\"presets\\": [\\"babel-preset-expo\\"],
-  \\"env\\": {
-    \\"development\\": {
-      \\"plugins\\": [\\"transform-react-jsx-source\\"]
-    }
-  }
-}"
-`;
-
 exports[`Templates React InstantSearch Native File content: .editorconfig 1`] = `
 "root = true
 
@@ -4399,9 +4388,20 @@ yarn start
 exports[`Templates React InstantSearch Native File content: app.json 1`] = `
 "{
   \\"expo\\": {
-    \\"sdkVersion\\": \\"30.0.1\\"
+    \\"name\\": \\"react-instantsearch-native-app\\",
+    \\"slug\\": \\"react-instantsearch-native-app\\",
+    \\"sdkVersion\\": \\"32.0.0\\"
   }
 }"
+`;
+
+exports[`Templates React InstantSearch Native File content: babel.config.js 1`] = `
+"module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};"
 `;
 
 exports[`Templates React InstantSearch Native File content: package.json 1`] = `
@@ -4409,13 +4409,12 @@ exports[`Templates React InstantSearch Native File content: package.json 1`] = `
   \\"name\\": \\"react-instantsearch-native-app\\",
   \\"version\\": \\"1.0.0\\",
   \\"private\\": true,
-  \\"main\\": \\"./node_modules/react-native-scripts/build/bin/crna-entry.js\\",
+  \\"main\\": \\"node_modules/expo/AppEntry.js\\",
   \\"scripts\\": {
-    \\"start\\": \\"react-native-scripts start\\",
-    \\"android\\": \\"react-native-scripts android\\",
-    \\"ios\\": \\"react-native-scripts ios\\",
-    \\"lint\\": \\"eslint .\\",
-    \\"lint:fix\\": \\"npm run lint -- --fix\\"
+    \\"start\\": \\"expo start\\",
+    \\"android\\": \\"expo start --android\\",
+    \\"ios\\": \\"expo start --ios\\",
+    \\"eject\\": \\"expo eject\\"
   },
   \\"partialDependencies\\": {
     \\"react-instantsearch-native\\": \\"5.2.0\\"
@@ -4557,7 +4556,6 @@ export default connectSearchBox(SearchBox);"
 
 exports[`Templates React InstantSearch Native Folder structure: contains the right files 1`] = `
 Array [
-  ".babelrc",
   ".editorconfig",
   ".eslintrc.js",
   ".gitignore",
@@ -4566,6 +4564,7 @@ Array [
   "App.js",
   "README.md",
   "app.json",
+  "babel.config.js",
   "package.json",
   "src/Highlight.js",
   "src/InfiniteHits.js",

--- a/src/templates/React InstantSearch Native/.babelrc.template
+++ b/src/templates/React InstantSearch Native/.babelrc.template
@@ -1,8 +1,0 @@
-{
-  "presets": ["babel-preset-expo"],
-  "env": {
-    "development": {
-      "plugins": ["transform-react-jsx-source"]
-    }
-  }
-}

--- a/src/templates/React InstantSearch Native/app.json
+++ b/src/templates/React InstantSearch Native/app.json
@@ -1,5 +1,7 @@
 {
   "expo": {
-    "sdkVersion": "30.0.1"
+    "name": "{{name}}",
+    "slug": "{{name}}",
+    "sdkVersion": "32.0.0"
   }
 }

--- a/src/templates/React InstantSearch Native/babel.config.js
+++ b/src/templates/React InstantSearch Native/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/src/templates/React InstantSearch Native/package.json
+++ b/src/templates/React InstantSearch Native/package.json
@@ -2,30 +2,30 @@
   "name": "{{name}}",
   "version": "1.0.0",
   "private": true,
-  "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
+  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "start": "react-native-scripts start",
-    "android": "react-native-scripts android",
-    "ios": "react-native-scripts ios",
-    "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix"
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "eject": "expo eject"
   },
   "dependencies": {
-    "algoliasearch": "3.30.0",
-    "expo": "30.0.1",
+    "algoliasearch": "3.32.1",
+    "expo": "32.0.0",
     "prop-types": "15.7.2",
-    "react": "16.6.3",
+    "react": "16.5.0",
     "react-instantsearch-native": "{{libraryVersion}}",
-    "react-native": "0.55.4"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz"
   },
   "devDependencies": {
+    "babel-preset-expo": "5.0.0",
     "eslint": "5.7.0",
     "eslint-config-algolia": "13.2.3",
     "eslint-config-prettier": "3.6.0",
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.11.1",
-    "prettier": "1.16.4",
-    "react-native-scripts": "1.14.1"
+    "expo-cli": "2.13.0",
+    "prettier": "1.16.4"
   }
 }


### PR DESCRIPTION
The template for React Native was not working anymore. I've updated it to use Expo rather than `create-react-native-app`. CRNA [have been deprecated](https://github.com/react-community/create-react-native-app) for the Expo version.