### PR TITLE
chore(ci): run complete E2E test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           name: Lint & Code styles
           command: yarn run lint
 
-  test_e2e_templates:
+  test_e2e:
     <<: *defaults
     steps:
       - checkout
@@ -85,8 +85,8 @@ jobs:
       - run: *run_yarn_install
       - save_cache: *save_yarn_cache
       - run:
-          name: End-to-end templates tests
-          command: yarn run test:e2e:templates --maxWorkers=4
+          name: End-to-end tests
+          command: yarn run test:e2e --maxWorkers=4
 
   test_apps_node_8:
     executor: node8
@@ -154,6 +154,6 @@ workflows:
     jobs:
       - test_lint
       - test_unit
-      - test_e2e_templates
+      - test_e2e
       - test_apps_node_8
       - test_apps_node_10


### PR DESCRIPTION
In #394 we changed the E2E process to build apps on the CI and only run the E2E tests regarding the templates generation. This also adds the [E2E tests regarding the app installation generation](https://github.com/algolia/create-instantsearch-app/blob/26f8f8c621f21b29e2d2caf22a0ab648a8874a06/e2e/installs.test.js) (decoupled with building all apps).