### PR TITLE
fix(templates): prepare InstantSearch template for v4

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -3229,43 +3229,33 @@ const search = instantsearch({
   searchClient,
 });
 
-const searchBox = instantsearch.widgets.searchBox({
-  container: '#searchbox',
-  placeholder: 'Search placeholder',
-});
-
-const hits = instantsearch.widgets.hits({
-  container: '#hits',
-  templates: {
-    item: \`
+search.addWidgets([
+  instantsearch.widgets.searchBox({
+    container: '#searchbox',
+    placeholder: 'Search placeholder',
+  }),
+  instantsearch.widgets.hits({
+    container: '#hits',
+    templates: {
+      item: \`
 <article>
   <h1>{{#helpers.highlight}}{ \\"attribute\\": \\"attribute1\\" }{{/helpers.highlight}}</h1>
   <p>{{#helpers.highlight}}{ \\"attribute\\": \\"attribute2\\" }{{/helpers.highlight}}</p>
 </article>
 \`,
-  },
-});
-
-const facet1RefinementList = instantsearch.widgets.refinementList({
-  container: '#facet1-list',
-  attribute: 'facet1',
-});
-
-const facet2RefinementList = instantsearch.widgets.refinementList({
-  container: '#facet2-list',
-  attribute: 'facet2',
-});
-
-const pagination = instantsearch.widgets.pagination({
-  container: '#pagination',
-});
-
-search.addWidgets([
-  searchBox,
-  hits,
-  facet1RefinementList,
-  facet2RefinementList,
-  pagination,
+    },
+  }),
+  instantsearch.widgets.refinementList({
+    container: '#facet1-list',
+    attribute: 'facet1',
+  }),
+  instantsearch.widgets.refinementList({
+    container: '#facet2-list',
+    attribute: 'facet2',
+  }),
+  instantsearch.widgets.pagination({
+    container: '#pagination',
+  }),
 ]);
 
 search.start();"

--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -3229,46 +3229,44 @@ const search = instantsearch({
   searchClient,
 });
 
-search.addWidget(
-  instantsearch.widgets.searchBox({
-    container: '#searchbox',
-    placeholder: 'Search placeholder',
-  })
-);
+const searchBox = instantsearch.widgets.searchBox({
+  container: '#searchbox',
+  placeholder: 'Search placeholder',
+});
 
-search.addWidget(
-  instantsearch.widgets.hits({
-    container: '#hits',
-    templates: {
-      item: \`
+const hits = instantsearch.widgets.hits({
+  container: '#hits',
+  templates: {
+    item: \`
 <article>
   <h1>{{#helpers.highlight}}{ \\"attribute\\": \\"attribute1\\" }{{/helpers.highlight}}</h1>
   <p>{{#helpers.highlight}}{ \\"attribute\\": \\"attribute2\\" }{{/helpers.highlight}}</p>
 </article>
 \`,
-    },
-  })
-);
+  },
+});
 
-search.addWidget(
-  instantsearch.widgets.refinementList({
-    container: '#facet1-list',
-    attribute: 'facet1',
-  })
-);
+const facet1RefinementList = instantsearch.widgets.refinementList({
+  container: '#facet1-list',
+  attribute: 'facet1',
+});
 
-search.addWidget(
-  instantsearch.widgets.refinementList({
-    container: '#facet2-list',
-    attribute: 'facet2',
-  })
-);
+const facet2RefinementList = instantsearch.widgets.refinementList({
+  container: '#facet2-list',
+  attribute: 'facet2',
+});
 
-search.addWidget(
-  instantsearch.widgets.pagination({
-    container: '#pagination',
-  })
-);
+const pagination = instantsearch.widgets.pagination({
+  container: '#pagination',
+});
+
+search.addWidgets([
+  searchBox,
+  hits,
+  facet1RefinementList,
+  facet2RefinementList,
+  pagination,
+]);
 
 search.start();"
 `;

--- a/src/templates/InstantSearch.js/src/app.js.hbs
+++ b/src/templates/InstantSearch.js/src/app.js.hbs
@@ -10,18 +10,18 @@ const search = instantsearch({
   searchClient,
 });
 
-const searchBox = instantsearch.widgets.searchBox({
-  container: '#searchbox',
-  {{#if searchPlaceholder}}
-  placeholder: '{{searchPlaceholder}}',
-  {{/if}}
-});
-
-const hits = instantsearch.widgets.hits({
-  container: '#hits',
-  {{#if attributesToDisplay}}
-  templates: {
-    item: `
+search.addWidgets([
+  instantsearch.widgets.searchBox({
+    container: '#searchbox',
+    {{#if searchPlaceholder}}
+    placeholder: '{{searchPlaceholder}}',
+    {{/if}}
+  }),
+  instantsearch.widgets.hits({
+    container: '#hits',
+    {{#if attributesToDisplay}}
+    templates: {
+      item: `
 <article>
   <h1>\{{#helpers.highlight}}{ "attribute": "{{attributesToDisplay.[0]}}" }\{{/helpers.highlight}}</h1>
   {{#each attributesToDisplay}}
@@ -31,28 +31,18 @@ const hits = instantsearch.widgets.hits({
   {{/each}}
 </article>
 `,
-  },
-  {{/if}}
-});
-
-{{#each attributesForFaceting}}
-const {{this}}RefinementList = instantsearch.widgets.refinementList({
-  container: '#{{this}}-list',
-  attribute: '{{this}}',
-});
-
-{{/each}}
-const pagination = instantsearch.widgets.pagination({
-  container: '#pagination',
-});
-
-search.addWidgets([
-  searchBox,
-  hits,
+    },
+    {{/if}}
+  }),
   {{#each attributesForFaceting}}
-  {{this}}RefinementList,
+  instantsearch.widgets.refinementList({
+    container: '#{{this}}-list',
+    attribute: '{{this}}',
+  }),
   {{/each}}
-  pagination
+  instantsearch.widgets.pagination({
+    container: '#pagination',
+  })
 ]);
 
 search.start();

--- a/src/templates/InstantSearch.js/src/app.js.hbs
+++ b/src/templates/InstantSearch.js/src/app.js.hbs
@@ -10,21 +10,18 @@ const search = instantsearch({
   searchClient,
 });
 
-search.addWidget(
-  instantsearch.widgets.searchBox({
-    container: '#searchbox',
-    {{#if searchPlaceholder}}
-    placeholder: '{{searchPlaceholder}}',
-    {{/if}}
-  })
-);
+const searchBox = instantsearch.widgets.searchBox({
+  container: '#searchbox',
+  {{#if searchPlaceholder}}
+  placeholder: '{{searchPlaceholder}}',
+  {{/if}}
+});
 
-search.addWidget(
-  instantsearch.widgets.hits({
-    container: '#hits',
-    {{#if attributesToDisplay}}
-    templates: {
-      item: `
+const hits = instantsearch.widgets.hits({
+  container: '#hits',
+  {{#if attributesToDisplay}}
+  templates: {
+    item: `
 <article>
   <h1>\{{#helpers.highlight}}{ "attribute": "{{attributesToDisplay.[0]}}" }\{{/helpers.highlight}}</h1>
   {{#each attributesToDisplay}}
@@ -34,24 +31,28 @@ search.addWidget(
   {{/each}}
 </article>
 `,
-    },
-    {{/if}}
-  })
-);
+  },
+  {{/if}}
+});
 
 {{#each attributesForFaceting}}
-search.addWidget(
-  instantsearch.widgets.refinementList({
-    container: '#{{this}}-list',
-    attribute: '{{this}}',
-  })
-);
+const {{this}}RefinementList = instantsearch.widgets.refinementList({
+  container: '#{{this}}-list',
+  attribute: '{{this}}',
+});
 
 {{/each}}
-search.addWidget(
-  instantsearch.widgets.pagination({
-    container: '#pagination',
-  })
-);
+const pagination = instantsearch.widgets.pagination({
+  container: '#pagination',
+});
+
+search.addWidgets([
+  searchBox,
+  hits,
+  {{#each attributesForFaceting}}
+  {{this}}RefinementList,
+  {{/each}}
+  pagination
+]);
 
 search.start();


### PR DESCRIPTION
This updates the InstantSearch.js 3 template with a newer syntax that we recommend for InstantSearch.js 4.

This has the benefits of also working with v4, and therefore we won't need to create another template.