### PR TITLE
feat(templates): allow InstantSearch.js template with v4

### DIFF
--- a/src/templates/InstantSearch.js/.template.js
+++ b/src/templates/InstantSearch.js/.template.js
@@ -4,7 +4,7 @@ const teardown = require('../../tasks/node/teardown');
 module.exports = {
   category: 'Web',
   libraryName: 'instantsearch.js',
-  supportedVersion: '>= 3.0.0 < 4.0.0',
+  supportedVersion: '>= 3.0.0 < 5.0.0',
   templateName: 'instantsearch.js',
   appName: 'instantsearch.js-app',
   keywords: ['algolia', 'InstantSearch', 'Vanilla', 'instantsearch.js'],


### PR DESCRIPTION
This allows to use the InstantSearch.js template with the newly released InstantSearch.js 4.