### PR TITLE
fix(templates): use function component in React template

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -4427,7 +4427,7 @@ exports[`Templates React InstantSearch File content: src/App.css 1`] = `
 `;
 
 exports[`Templates React InstantSearch File content: src/App.js 1`] = `
-"import React, { Component } from 'react';
+"import React from 'react';
 import algoliasearch from 'algoliasearch/lite';
 import {
   InstantSearch,
@@ -4442,49 +4442,47 @@ import './App.css';
 
 const searchClient = algoliasearch('appId', 'apiKey');
 
-class App extends Component {
-  render() {
-    return (
-      <div>
-        <header className=\\"header\\">
-          <h1 className=\\"header-title\\">
-            <a href=\\"/\\">react-instantsearch-app</a>
-          </h1>
-          <p className=\\"header-subtitle\\">
-            using{' '}
-            <a href=\\"https://github.com/algolia/react-instantsearch\\">
-              React InstantSearch
-            </a>
-          </p>
-        </header>
+function App() {
+  return (
+    <div>
+      <header className=\\"header\\">
+        <h1 className=\\"header-title\\">
+          <a href=\\"/\\">react-instantsearch-app</a>
+        </h1>
+        <p className=\\"header-subtitle\\">
+          using{' '}
+          <a href=\\"https://github.com/algolia/react-instantsearch\\">
+            React InstantSearch
+          </a>
+        </p>
+      </header>
 
-        <div className=\\"container\\">
-          <InstantSearch searchClient={searchClient} indexName=\\"indexName\\">
-            <div className=\\"search-panel\\">
-              <div className=\\"search-panel__filters\\">
-                <RefinementList attribute=\\"facet1\\" />
-                <RefinementList attribute=\\"facet2\\" />
-              </div>
+      <div className=\\"container\\">
+        <InstantSearch searchClient={searchClient} indexName=\\"indexName\\">
+          <div className=\\"search-panel\\">
+            <div className=\\"search-panel__filters\\">
+              <RefinementList attribute=\\"facet1\\" />
+              <RefinementList attribute=\\"facet2\\" />
+            </div>
 
-              <div className=\\"search-panel__results\\">
-                <SearchBox
-                  className=\\"searchbox\\"
-                  translations={{
-                    placeholder: 'Search placeholder',
-                  }}
-                />
-                <Hits hitComponent={Hit} />
+            <div className=\\"search-panel__results\\">
+              <SearchBox
+                className=\\"searchbox\\"
+                translations={{
+                  placeholder: 'Search placeholder',
+                }}
+              />
+              <Hits hitComponent={Hit} />
 
-                <div className=\\"pagination\\">
-                  <Pagination />
-                </div>
+              <div className=\\"pagination\\">
+                <Pagination />
               </div>
             </div>
-          </InstantSearch>
-        </div>
+          </div>
+        </InstantSearch>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 function Hit(props) {

--- a/src/templates/React InstantSearch/src/App.js.hbs
+++ b/src/templates/React InstantSearch/src/App.js.hbs
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import algoliasearch from 'algoliasearch/lite';
 import {
   InstantSearch,
@@ -17,52 +17,50 @@ import './App.css';
 
 const searchClient = algoliasearch('{{appId}}', '{{apiKey}}');
 
-class App extends Component {
-  render() {
-    return (
-      <div>
-        <header className="header">
-          <h1 className="header-title">
-            <a href="/">{{name}}</a>
-          </h1>
-          <p className="header-subtitle">
-            using{' '}
-            <a href="https://github.com/algolia/react-instantsearch">
-              React InstantSearch
-            </a>
-          </p>
-        </header>
+function App() {
+  return (
+    <div>
+      <header className="header">
+        <h1 className="header-title">
+          <a href="/">{{name}}</a>
+        </h1>
+        <p className="header-subtitle">
+          using{' '}
+          <a href="https://github.com/algolia/react-instantsearch">
+            React InstantSearch
+          </a>
+        </p>
+      </header>
 
-        <div className="container">
-          <InstantSearch searchClient={searchClient} indexName="{{indexName}}">
-            <div className="search-panel">
-              {{#if attributesForFaceting}}
-              <div className="search-panel__filters">
-                {{#each attributesForFaceting}}
-                <RefinementList attribute="{{this}}" />
-                {{/each}}
-              </div>
+      <div className="container">
+        <InstantSearch searchClient={searchClient} indexName="{{indexName}}">
+          <div className="search-panel">
+            {{#if attributesForFaceting}}
+            <div className="search-panel__filters">
+              {{#each attributesForFaceting}}
+              <RefinementList attribute="{{this}}" />
+              {{/each}}
+            </div>
 
-              {{/if}}
-              <div className="search-panel__results">
-                <SearchBox
-                  className="searchbox"
-                  translations=\{{
-                    placeholder: '{{searchPlaceholder}}',
-                  }}
-                />
-                <Hits hitComponent={Hit} />
+            {{/if}}
+            <div className="search-panel__results">
+              <SearchBox
+                className="searchbox"
+                translations=\{{
+                  placeholder: '{{searchPlaceholder}}',
+                }}
+              />
+              <Hits hitComponent={Hit} />
 
-                <div className="pagination">
-                  <Pagination />
-                </div>
+              <div className="pagination">
+                <Pagination />
               </div>
             </div>
-          </InstantSearch>
-        </div>
+          </div>
+        </InstantSearch>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 function Hit(props) {


### PR DESCRIPTION
This updates the React template to a more modern way with a function component. We use React 16.12.0 where hooks are available, so there's no need for a class.