### PR TITLE
feat(cli): make app path optional

### DIFF
--- a/e2e/installs.test.js
+++ b/e2e/installs.test.js
@@ -4,6 +4,7 @@ const { execSync } = require('child_process');
 describe('Installation', () => {
   let temporaryDirectory;
   let appPath;
+  const appName = 'test-app';
 
   beforeAll(() => {
     temporaryDirectory = execSync(
@@ -18,7 +19,7 @@ describe('Installation', () => {
   });
 
   beforeEach(() => {
-    appPath = `${temporaryDirectory}/test-app`;
+    appPath = `${temporaryDirectory}/${appName}`;
     execSync(`mkdir ${appPath}`);
   });
 
@@ -30,6 +31,7 @@ describe('Installation', () => {
     test('get skipped with the `no-installation` flag', () => {
       execSync(
         `yarn start ${appPath} \
+          --name ${appName} \
           --template "InstantSearch.js" \
           --no-installation`,
         { stdio: 'ignore' }
@@ -43,6 +45,7 @@ describe('Installation', () => {
     test('without conflict generates files', () => {
       execSync(
         `yarn start ${appPath} \
+          --name ${appName} \
           --template "InstantSearch.js" \
           --no-installation`,
         { stdio: 'ignore' }
@@ -57,6 +60,7 @@ describe('Installation', () => {
       expect(() => {
         execSync(
           `yarn start ${appPath} \
+          --name ${appName} \
           --template "InstantSearch.js" \
           --no-installation`,
           { stdio: 'ignore' }
@@ -76,6 +80,7 @@ describe('Installation', () => {
       expect(() => {
         execSync(
           `yarn start ${appPath}/file \
+          --name ${appName} \
           --template "InstantSearch.js" \
           --no-installation`,
           { stdio: 'ignore' }

--- a/e2e/templates.test.js
+++ b/e2e/templates.test.js
@@ -57,6 +57,7 @@ describe('Templates', () => {
 
         execSync(
           `yarn start ${appPath} \
+              --name ${templateConfig.appName} \
               --config ${configFilePath} \
               --no-installation`,
           { stdio: 'ignore' }

--- a/scripts/build-app.js
+++ b/scripts/build-app.js
@@ -18,8 +18,11 @@ if (!templateName) {
   process.exit(1);
 }
 
+const appName = path.basename(appPath);
+
 execSync(
   `yarn start ${appPath} \
+    --name "${appName}" \
     --template "${templateName}"`,
   { stdio: 'inherit' }
 );

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -188,7 +188,7 @@ async function run() {
       {
         type: 'input',
         name: 'appPath',
-        message: 'Project directory:',
+        message: 'Project directory',
       },
     ]);
     appPath = answers.appPath;
@@ -212,7 +212,7 @@ async function run() {
         {
           type: 'input',
           name: 'appName',
-          message: 'The name of the application or widget: ',
+          message: 'The name of the application or widget',
           default: path.basename(appPath),
         },
       ])

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -196,7 +196,6 @@ async function run() {
   if (appPath.startsWith('~/')) {
     appPath = path.join(os.homedir(), appPath.slice(2));
   }
-  let appName = optionsFromArguments.name || path.basename(appPath);
   try {
     checkAppPath(appPath);
   } catch (err) {
@@ -206,16 +205,19 @@ async function run() {
     process.exit(1);
   }
 
-  appName = (
-    await inquirer.prompt([
-      {
-        type: 'input',
-        name: 'appName',
-        message: 'The name of the application or widget: ',
-        default: appName,
-      },
-    ])
-  ).appName;
+  let appName = optionsFromArguments.name;
+  if (!appName) {
+    appName = (
+      await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'appName',
+          message: 'The name of the application or widget: ',
+          default: path.basename(appPath),
+        },
+      ])
+    ).appName;
+  }
 
   try {
     checkAppName(appName);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -5,6 +5,7 @@ const program = require('commander');
 const inquirer = require('inquirer');
 const chalk = require('chalk');
 const latestSemver = require('latest-semver');
+const os = require('os');
 
 const createInstantSearchApp = require('../api');
 const {
@@ -25,14 +26,14 @@ const {
 } = require('./getConfiguration');
 const { version } = require('../../package.json');
 
-let appPath;
+let appPathFromArgument;
 let options = {};
 
 program
   .version(version, '-v, --version')
   .arguments('<project-directory>')
   .usage(`${chalk.green('<project-directory>')} [options]`)
-  .option('--name <name>', 'The name of the application')
+  .option('--name <name>', 'The name of the application or widget')
   .option('--app-id <appId>', 'The application ID')
   .option('--api-key <apiKey>', 'The Algolia search API key')
   .option('--index-name <indexName>', 'The main index of your search')
@@ -49,52 +50,18 @@ program
   .option('--config <config>', 'The configuration file to get the options from')
   .option('--no-installation', 'Ignore dependency installation')
   .action((dest, opts) => {
-    appPath = dest;
+    appPathFromArgument = dest;
     options = opts;
   })
   .parse(process.argv);
 
-if (!appPath) {
-  console.log('Please specify the project directory:');
-  console.log();
-  console.log(
-    `  ${chalk.cyan('create-instantsearch-app')} ${chalk.green(
-      '<project-directory>'
-    )}`
-  );
-  console.log();
-  console.log('For example:');
-  console.log(
-    `  ${chalk.cyan('create-instantsearch-app')} ${chalk.green(
-      'my-instantsearch-app'
-    )}`
-  );
-  console.log();
-  console.log(
-    `Run ${chalk.cyan('create-instantsearch-app --help')} to see all options.`
-  );
-
-  process.exit(1);
-}
-
-const optionsFromArguments = getOptionsFromArguments(options.rawArgs);
-const appName = optionsFromArguments.name || path.basename(appPath);
+const optionsFromArguments = getOptionsFromArguments(options.rawArgs || []);
 const attributesToDisplay = (optionsFromArguments.attributesToDisplay || '')
   .split(',')
   .filter(Boolean)
   .map(x => x.trim());
 
-try {
-  checkAppPath(appPath);
-  checkAppName(appName);
-} catch (err) {
-  console.error(err.message);
-  console.log();
-
-  process.exit(1);
-}
-
-const questions = {
+const getQuestions = ({ appName }) => ({
   application: [
     {
       type: 'list',
@@ -212,9 +179,53 @@ const questions = {
       },
     },
   ],
-};
+});
 
 async function run() {
+  let appPath = appPathFromArgument;
+  if (!appPath) {
+    const answers = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'appPath',
+        message: 'Project directory:',
+      },
+    ]);
+    appPath = answers.appPath;
+  }
+  if (appPath.startsWith('~/')) {
+    appPath = path.join(os.homedir(), appPath.slice(2));
+  }
+  let appName = optionsFromArguments.name || path.basename(appPath);
+  try {
+    checkAppPath(appPath);
+  } catch (err) {
+    console.error(err.message);
+    console.log();
+
+    process.exit(1);
+  }
+
+  appName = (
+    await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'appName',
+        message: 'The name of the application or widget: ',
+        default: appName,
+      },
+    ])
+  ).appName;
+
+  try {
+    checkAppName(appName);
+  } catch (err) {
+    console.error(err.message);
+    console.log();
+
+    process.exit(1);
+  }
+
   console.log();
   console.log(`Creating a new InstantSearch app in ${chalk.green(appPath)}.`);
   console.log();
@@ -264,7 +275,7 @@ async function run() {
     templateConfig.category === 'Widget' ? 'widget' : 'application';
 
   const answers = await inquirer.prompt(
-    questions[implementationType].filter(question =>
+    getQuestions({ appName })[implementationType].filter(question =>
       isQuestionAsked({ question, args: optionsFromArguments })
     ),
     { ...optionsFromArguments, template }


### PR DESCRIPTION
## Summary

* This PR makes <project directory> argument optional.
  (`npx create-instantsearch-app` will asks for the directory)
* After inferring project name from the directory, it asks if you want to name it differently.

## Examples

### Example 1

(path provided)

```
$ npx create-instantsearch-app ~/workspace/date-picker

The name of the application or widget: [date-picker]
```

`date-picker` is given as a default name but you can change there.

### Example 2

(path not provided)

```
$ npx create-instantsearch-app

Project directory: 
```

Let's say you typed `date-picker`, then the next step would be:

```
The name of the application or widget: [date-picker]
```

The name is inferred from the path but again lets you update it.