### PR TITLE
feat(is widget): upgrade to standard types

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -4139,7 +4139,7 @@ exports[`Templates InstantSearch.js widget File content: package.json 1`] = `
     \\"dist\\"
   ],
   \\"peerDependencies\\": {
-    \\"instantsearch.js\\": \\"^4.0.0\\"
+    \\"instantsearch.js\\": \\"^4.27.1\\"
   },
   \\"browserslist\\": [
     \\"last 2 chrome versions\\",
@@ -4349,7 +4349,7 @@ exports[`Templates InstantSearch.js widget File content: src/types.ts 1`] = `
   Renderer,
   Connector,
   WidgetFactory,
-} from 'instantsearch.js/es/types';
+} from 'instantsearch.js/es';
 
 /*
  * Parameters send only to the widget creator function

--- a/src/templates/InstantSearch.js widget/.template.js
+++ b/src/templates/InstantSearch.js widget/.template.js
@@ -4,7 +4,7 @@ const teardown = require('../../tasks/node/teardown');
 module.exports = {
   category: 'Widget',
   libraryName: 'instantsearch.js',
-  supportedVersion: '>= 4.21.0 < 5.0.0',
+  supportedVersion: '>= 4.27.1 < 5.0.0',
   templateName: 'instantsearch.js-widget',
   packageNamePrefix: 'instantsearch-widget-',
   keywords: [

--- a/src/templates/InstantSearch.js widget/package.json.hbs
+++ b/src/templates/InstantSearch.js widget/package.json.hbs
@@ -34,7 +34,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "instantsearch.js": "^4.0.0"
+    "instantsearch.js": "^4.27.1"
   },
   "devDependencies": {
     "@babel/cli": "7.13.10",
@@ -60,7 +60,7 @@
     "eslint-plugin-jest": "24.1.5",
     "eslint-plugin-jsdoc": "32.2.0",
     "eslint-plugin-prettier": "3.3.1",
-    "instantsearch.js": "{{ libraryVersion }}-experimental-typescript.0",
+    "instantsearch.js": "{{ libraryVersion }}",
     "jest": "26.6.3",
     "prettier": "2.2.1",
     "rollup-plugin-api-extractor": "0.2.2",

--- a/src/templates/InstantSearch.js widget/src/types.ts.hbs
+++ b/src/templates/InstantSearch.js widget/src/types.ts.hbs
@@ -2,7 +2,7 @@ import type {
   Renderer,
   Connector,
   WidgetFactory,
-} from 'instantsearch.js/es/types';
+} from 'instantsearch.js/es';
 
 /*
  * Parameters send only to the widget creator function


### PR DESCRIPTION
This makes the TS integration no longer need `experimental-typescript`