### PR TITLE
feat(js): add typescript to the js template

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -3281,35 +3281,12 @@ search.start();"
 
 exports[`Templates InstantSearch.js File content: src/global.d.ts 1`] = `
 "import algoliasearch from 'algoliasearch/lite';
-
 import instantsearch from 'instantsearch.js/es';
-import * as connectors from 'instantsearch.js/es/connectors';
-import * as widgets from 'instantsearch.js/es/widgets';
-import * as middlewares from 'instantsearch.js/es/middlewares';
-import * as helpers from 'instantsearch.js/es/helpers/index';
-import * as routers from 'instantsearch.js/es/lib/routers/index';
-import * as stateMappings from 'instantsearch.js/es/lib/stateMappings/index';
-import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/lib/infiniteHitsCache/index';
 
 declare global {
   interface Window {
     algoliasearch: typeof algoliasearch;
-
-    instantsearch: typeof instantsearch & {
-      connectors: typeof connectors;
-      widgets: typeof widgets;
-      middlewares: typeof middlewares;
-
-      routers: typeof routers;
-      stateMappings: typeof stateMappings;
-
-      createInfiniteHitsSessionStorageCache: typeof createInfiniteHitsSessionStorageCache;
-      highlight: typeof helpers.highlight;
-      reverseHighlight: typeof helpers.reverseHighlight;
-      snippet: typeof helpers.snippet;
-      reverseSnippet: typeof helpers.reverseSnippet;
-      insights: typeof helpers.insights;
-    };
+    instantsearch: typeof instantsearch;
   }
 }"
 `;

--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -3130,7 +3130,7 @@ exports[`Templates InstantSearch.js File content: index.html 1`] = `
     <div id=\\"pagination\\"></div>
   </div>
 
-  <script src=\\"https://cdn.jsdelivr.net/algoliasearch/3.32.0/algoliasearchLite.min.js\\"></script>
+  <script src=\\"https://cdn.jsdelivr.net/algoliasearch/4.10.4/algoliasearchLite.min.js\\"></script>
   <script src=\\"https://cdn.jsdelivr.net/npm/instantsearch.js@3.0.0\\"></script>
   <script src=\\"./src/app.js\\"></script>
 </body>
@@ -3168,7 +3168,9 @@ exports[`Templates InstantSearch.js File content: package.json 1`] = `
     \\"lint\\": \\"eslint .\\",
     \\"lint:fix\\": \\"npm run lint -- --fix\\"
   },
-  \\"partialDependencies\\": {}
+  \\"partialDependencies\\": {
+    \\"instantsearch.js\\": \\"3.0.0\\"
+  }
 }"
 `;
 
@@ -3277,6 +3279,41 @@ search.addWidgets([
 search.start();"
 `;
 
+exports[`Templates InstantSearch.js File content: src/global.d.ts 1`] = `
+"import algoliasearch from 'algoliasearch/lite';
+
+import instantsearch from 'instantsearch.js/es';
+import * as connectors from 'instantsearch.js/es/connectors';
+import * as widgets from 'instantsearch.js/es/widgets';
+import * as middlewares from 'instantsearch.js/es/middlewares';
+import * as helpers from 'instantsearch.js/es/helpers/index';
+import * as routers from 'instantsearch.js/es/lib/routers/index';
+import * as stateMappings from 'instantsearch.js/es/lib/stateMappings/index';
+import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/lib/infiniteHitsCache/index';
+
+declare global {
+  interface Window {
+    algoliasearch: typeof algoliasearch;
+
+    instantsearch: typeof instantsearch & {
+      connectors: typeof connectors;
+      widgets: typeof widgets;
+      middlewares: typeof middlewares;
+
+      routers: typeof routers;
+      stateMappings: typeof stateMappings;
+
+      createInfiniteHitsSessionStorageCache: typeof createInfiniteHitsSessionStorageCache;
+      highlight: typeof helpers.highlight;
+      reverseHighlight: typeof helpers.reverseHighlight;
+      snippet: typeof helpers.snippet;
+      reverseSnippet: typeof helpers.reverseSnippet;
+      insights: typeof helpers.insights;
+    };
+  }
+}"
+`;
+
 exports[`Templates InstantSearch.js File content: src/index.css 1`] = `
 "body,
 h1 {
@@ -3287,6 +3324,27 @@ h1 {
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}"
+`;
+
+exports[`Templates InstantSearch.js File content: tsconfig.json 1`] = `
+"{
+  \\"compilerOptions\\": {
+    \\"module\\": \\"commonjs\\",
+    \\"esModuleInterop\\": true,
+    \\"sourceMap\\": true,
+    \\"allowJs\\": true,
+    \\"lib\\": [
+      \\"es6\\",
+      \\"dom\\"
+    ],
+    \\"rootDir\\": \\"src\\",
+    \\"moduleResolution\\": \\"node\\"
+  },
+  \\"include\\": [
+    \\"src\\",
+    \\"src/global.d.ts\\"
+  ]
 }"
 `;
 
@@ -3304,7 +3362,9 @@ Array [
   "package.json",
   "src/app.css",
   "src/app.js",
+  "src/global.d.ts",
   "src/index.css",
+  "tsconfig.json",
 ]
 `;
 

--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -3281,7 +3281,7 @@ search.start();"
 
 exports[`Templates InstantSearch.js File content: src/global.d.ts 1`] = `
 "import algoliasearch from 'algoliasearch/lite';
-import instantsearch from 'instantsearch.js/es';
+import instantsearch from 'instantsearch.js/dist/instantsearch.production.min';
 
 declare global {
   interface Window {

--- a/src/templates/InstantSearch.js/index.html.hbs
+++ b/src/templates/InstantSearch.js/index.html.hbs
@@ -48,7 +48,7 @@
     <div id="pagination"></div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/algoliasearch/3.32.0/algoliasearchLite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/algoliasearch/4.10.4/algoliasearchLite.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@{{libraryVersion}}"></script>
   <script src="./src/app.js"></script>
 </body>

--- a/src/templates/InstantSearch.js/package.json
+++ b/src/templates/InstantSearch.js/package.json
@@ -18,5 +18,9 @@
     "eslint-plugin-prettier": "3.1.2",
     "parcel-bundler": "1.12.5",
     "prettier": "1.19.1"
+  },
+  "dependencies": {
+    "algoliasearch": "4.10.4",
+    "instantsearch.js": "{{libraryVersion}}"
   }
 }

--- a/src/templates/InstantSearch.js/src/global.d.ts.hbs
+++ b/src/templates/InstantSearch.js/src/global.d.ts.hbs
@@ -1,0 +1,32 @@
+import algoliasearch from 'algoliasearch/lite';
+
+import instantsearch from 'instantsearch.js/es';
+import * as connectors from 'instantsearch.js/es/connectors';
+import * as widgets from 'instantsearch.js/es/widgets';
+import * as middlewares from 'instantsearch.js/es/middlewares';
+import * as helpers from 'instantsearch.js/es/helpers/index';
+import * as routers from 'instantsearch.js/es/lib/routers/index';
+import * as stateMappings from 'instantsearch.js/es/lib/stateMappings/index';
+import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/lib/infiniteHitsCache/index';
+
+declare global {
+  interface Window {
+    algoliasearch: typeof algoliasearch;
+
+    instantsearch: typeof instantsearch & {
+      connectors: typeof connectors;
+      widgets: typeof widgets;
+      middlewares: typeof middlewares;
+
+      routers: typeof routers;
+      stateMappings: typeof stateMappings;
+
+      createInfiniteHitsSessionStorageCache: typeof createInfiniteHitsSessionStorageCache;
+      highlight: typeof helpers.highlight;
+      reverseHighlight: typeof helpers.reverseHighlight;
+      snippet: typeof helpers.snippet;
+      reverseSnippet: typeof helpers.reverseSnippet;
+      insights: typeof helpers.insights;
+    };
+  }
+}

--- a/src/templates/InstantSearch.js/src/global.d.ts.hbs
+++ b/src/templates/InstantSearch.js/src/global.d.ts.hbs
@@ -1,5 +1,5 @@
 import algoliasearch from 'algoliasearch/lite';
-import instantsearch from 'instantsearch.js/es';
+import instantsearch from 'instantsearch.js/dist/instantsearch.production.min';
 
 declare global {
   interface Window {

--- a/src/templates/InstantSearch.js/src/global.d.ts.hbs
+++ b/src/templates/InstantSearch.js/src/global.d.ts.hbs
@@ -1,32 +1,9 @@
 import algoliasearch from 'algoliasearch/lite';
-
 import instantsearch from 'instantsearch.js/es';
-import * as connectors from 'instantsearch.js/es/connectors';
-import * as widgets from 'instantsearch.js/es/widgets';
-import * as middlewares from 'instantsearch.js/es/middlewares';
-import * as helpers from 'instantsearch.js/es/helpers/index';
-import * as routers from 'instantsearch.js/es/lib/routers/index';
-import * as stateMappings from 'instantsearch.js/es/lib/stateMappings/index';
-import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/lib/infiniteHitsCache/index';
 
 declare global {
   interface Window {
     algoliasearch: typeof algoliasearch;
-
-    instantsearch: typeof instantsearch & {
-      connectors: typeof connectors;
-      widgets: typeof widgets;
-      middlewares: typeof middlewares;
-
-      routers: typeof routers;
-      stateMappings: typeof stateMappings;
-
-      createInfiniteHitsSessionStorageCache: typeof createInfiniteHitsSessionStorageCache;
-      highlight: typeof helpers.highlight;
-      reverseHighlight: typeof helpers.reverseHighlight;
-      snippet: typeof helpers.snippet;
-      reverseSnippet: typeof helpers.reverseSnippet;
-      insights: typeof helpers.insights;
-    };
+    instantsearch: typeof instantsearch;
   }
 }

--- a/src/templates/InstantSearch.js/tsconfig.json
+++ b/src/templates/InstantSearch.js/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "allowJs": true,
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "rootDir": "src",
+    "moduleResolution": "node"
+  },
+  "include": [
+    "src",
+    "src/global.d.ts"
+  ]
+}


### PR DESCRIPTION
Since https://github.com/algolia/instantsearch.js/pull/4844 the UMD has type definitions exposed, which we can use in codesandbox, even when the file itself isn't written in TypeScript, or using modules