### PR TITLE
feat(vue): support Vue InstantSearch 4

### DIFF
--- a/src/templates/Vue InstantSearch/.template.js
+++ b/src/templates/Vue InstantSearch/.template.js
@@ -5,7 +5,7 @@ module.exports = {
   category: 'Web',
   libraryName: 'vue-instantsearch',
   templateName: 'vue-instantsearch',
-  supportedVersion: '>= 3.0.0 < 4.0.0',
+  supportedVersion: '>= 3.0.0 < 5.0.0',
   appName: 'vue-instantsearch-app',
   keywords: ['algolia', 'InstantSearch', 'Vue', 'vue-instantsearch'],
   tasks: {


### PR DESCRIPTION
not yet added a new template for Vue 3, that can be done later by @eunjae-lee, but this template doesn't touch any of the breaking changes in v4

This PR fixes CI