### PR TITLE
fix(Angular IS): enable esModuleInterop

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -604,6 +604,7 @@ exports[`Templates Angular InstantSearch File content: tsconfig.json 1`] = `
     \\"downlevelIteration\\": true,
     \\"experimentalDecorators\\": true,
     \\"moduleResolution\\": \\"node\\",
+    \\"esModuleInterop\\": true,
     \\"importHelpers\\": true,
     \\"target\\": \\"es2017\\",
     \\"module\\": \\"es2020\\",

--- a/src/templates/Angular InstantSearch/tsconfig.json
+++ b/src/templates/Angular InstantSearch/tsconfig.json
@@ -13,6 +13,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",


### PR DESCRIPTION
This works around a problem you can encounter on codeandbox.
Could using client-search instead of algoliasearch/lite better solve this problem? @Haroenv @francoischalifour 

```
lite_1.default is not a function
```
![Screenshot at Sep 20 17-16-36](https://user-images.githubusercontent.com/2982512/134027761-055fab15-53f0-4dc0-b374-cd9f92554cdb.png)
