### PR TITLE
fix(cli): configure inquirer with correct initial values for attributesToDisplay

### DIFF
--- a/src/cli/__tests__/getAnswersDefaultValues.js
+++ b/src/cli/__tests__/getAnswersDefaultValues.js
@@ -1,0 +1,15 @@
+const getAnswersDefaultValues = require('../getAnswersDefaultValues');
+
+test('without attributesToDisplay in configuration', () => {
+  const { attributesToDisplay } = getAnswersDefaultValues({}, {}, undefined);
+  expect(attributesToDisplay).toBeUndefined();
+});
+
+test('with attributesToDisplay in configuration', () => {
+  const { attributesToDisplay } = getAnswersDefaultValues(
+    {},
+    { attributesToDisplay: ['name'] },
+    undefined
+  );
+  expect(attributesToDisplay).toEqual(['name']);
+});

--- a/src/cli/getAnswersDefaultValues.js
+++ b/src/cli/getAnswersDefaultValues.js
@@ -1,0 +1,15 @@
+module.exports = function getAnswersDefaultValues(
+  optionsFromArguments,
+  configuration,
+  template
+) {
+  return {
+    ...optionsFromArguments,
+    template,
+    attributesToDisplay:
+      configuration.attributesToDisplay &&
+      configuration.attributesToDisplay.length > 0
+        ? configuration.attributesToDisplay
+        : undefined,
+  };
+};

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -18,6 +18,7 @@ const {
 } = require('../utils');
 const getOptionsFromArguments = require('./getOptionsFromArguments');
 const getAttributesFromIndex = require('./getAttributesFromIndex');
+const getAnswersDefaultValues = require('./getAnswersDefaultValues');
 const isQuestionAsked = require('./isQuestionAsked');
 const {
   getConfiguration,
@@ -280,15 +281,7 @@ async function run() {
     getQuestions({ appName })[implementationType].filter(question =>
       isQuestionAsked({ question, args: optionsFromArguments })
     ),
-    {
-      ...optionsFromArguments,
-      template,
-      attributesToDisplay:
-        configuration.attributesToDisplay &&
-        configuration.attributesToDisplay.length > 0
-          ? configuration.attributesToDisplay
-          : undefined,
-    }
+    getAnswersDefaultValues(optionsFromArguments, configuration, template)
   );
 
   const alternativeNames = createNameAlternatives({


### PR DESCRIPTION
This addresses an issue I had when using the CLI to create InstantSearch app, while following the documentation.

When specifying the `--attributes-to-display` parameter, the `Hit` component would render incorrectly because the template engine assumed the attributes to be in an array, while it was actually a string. Here is the generated output (for `--attributes-to-display name`):

```js
function Hit(props) {
  return (
    <article>
      <h1>
        <Highlight attribute="n" hit={props.hit} />
      </h1>
    </article>
  );
}
```

To fix that, I added to inquirer the array obtained from `getConfiguration()` in the initial values parameter.