### PR TITLE
fix(ci): replace legacy circleci node images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,15 +25,15 @@ aliases:
 defaults: &defaults
   working_directory: ~/create-instantsearch-app
   docker:
-    - image: circleci/node:12
+    - image: cimg/node:12.22
 
 executors:
   node10:
     docker:
-      - image: circleci/node:10
+      - image: cimg/node:10.24
   node12:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12.22
 
 commands:
   build_app:


### PR DESCRIPTION
This PR fixes the issue related to the legacy `circleci/node:10` image, that contains an expired CA certificate for Let's Encrypt, preventing the specific version of Yarn we use from being installed, failing the job.

While doing this, I also replaced the image we use for node 12, following the same principle.

> Please note that the failing **test_apps_node_12** job is unrelated to this change, and will be addressed in #532 after this is merged.