### PR TITLE
fix(angular): replace css imports with CDN <link>s

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -441,7 +441,6 @@ exports[`Templates Angular InstantSearch File content: src/index.html 1`] = `
   <base href=\\"/\\">
   <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
   <link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"favicon.ico\\">
-  <link href=\\"https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/reset.css\\" rel=\\"stylesheet\\" />
   <link href=\\"https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css\\" rel=\\"stylesheet\\" />
 </head>
 <body>

--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -101,7 +101,6 @@ exports[`Templates Angular InstantSearch File content: angular.json 1`] = `
               \\"src/assets\\"
             ],
             \\"styles\\": [
-              \\"node_modules/instantsearch.css/themes/satellite.css\\",
               \\"src/styles.css\\"
             ],
             \\"scripts\\": []
@@ -442,6 +441,8 @@ exports[`Templates Angular InstantSearch File content: src/index.html 1`] = `
   <base href=\\"/\\">
   <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
   <link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"favicon.ico\\">
+  <link href=\\"https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/reset.css\\" rel=\\"stylesheet\\" />
+  <link href=\\"https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css\\" rel=\\"stylesheet\\" />
 </head>
 <body>
   <app-root></app-root>

--- a/src/templates/Angular InstantSearch/angular.json
+++ b/src/templates/Angular InstantSearch/angular.json
@@ -27,7 +27,6 @@
               "src/assets"
             ],
             "styles": [
-              "node_modules/instantsearch.css/themes/satellite.css",
               "src/styles.css"
             ],
             "scripts": []

--- a/src/templates/Angular InstantSearch/src/index.html
+++ b/src/templates/Angular InstantSearch/src/index.html
@@ -6,7 +6,6 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/reset.css" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
 </head>
 <body>

--- a/src/templates/Angular InstantSearch/src/index.html
+++ b/src/templates/Angular InstantSearch/src/index.html
@@ -6,6 +6,8 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/reset.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
Using CSS from node_modules is causing problems with CodeSandbox
cf. https://github.com/codesandbox/codesandbox-client/issues/6235