### PR TITLE
feat(questions): ask optional non-answered questions

### DIFF
--- a/src/cli/isQuestionAsked.js
+++ b/src/cli/isQuestionAsked.js
@@ -12,9 +12,6 @@ module.exports = function isQuestionAsked({ question, args }) {
       ) {
         return false;
       }
-    } else if (!question.validate) {
-      // Skip if the question is optional and not given in the command
-      return false;
     }
   }
 


### PR DESCRIPTION
Before this PR we wouldn't ask optional questions, but this means if you pass that the app is React InstantSearch for example, attributesForFaceting will no longer be asked, neither will the version