### PR TITLE
fix(react): add missing configure widget import

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -5720,6 +5720,7 @@ import {
   InstantSearch,
   Hits,
   SearchBox,
+  Configure,
   RefinementList,
   Pagination,
   Highlight,

--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -5720,7 +5720,6 @@ import {
   InstantSearch,
   Hits,
   SearchBox,
-  Configure,
   RefinementList,
   Pagination,
   Highlight,

--- a/src/templates/React InstantSearch/src/App.js.hbs
+++ b/src/templates/React InstantSearch/src/App.js.hbs
@@ -4,8 +4,8 @@ import {
   InstantSearch,
   Hits,
   SearchBox,
-  Configure,
   {{#if flags.dynamicWidgets}}
+  Configure,
   ExperimentalDynamicWidgets,
   {{/if}}
   {{#if attributesForFaceting}}

--- a/src/templates/React InstantSearch/src/App.js.hbs
+++ b/src/templates/React InstantSearch/src/App.js.hbs
@@ -4,6 +4,7 @@ import {
   InstantSearch,
   Hits,
   SearchBox,
+  Configure,
   {{#if flags.dynamicWidgets}}
   ExperimentalDynamicWidgets,
   {{/if}}


### PR DESCRIPTION
This PR adds a missing import that prevented the React template for working in the latest release.