### PR TITLE
fix(angular): remove @types/algoliasearch dep

### DIFF
--- a/src/templates/Angular InstantSearch/package.json
+++ b/src/templates/Angular InstantSearch/package.json
@@ -28,7 +28,6 @@
     "@angular-devkit/build-angular": "12.2.3",
     "@angular/cli": "12.2.3",
     "@angular/compiler-cli": "12.2.0",
-    "@types/algoliasearch": "4.0.0",
     "@types/jasmine": "3.8.0",
     "@types/node": "12.11.1",
     "jasmine-core": "3.8.0",


### PR DESCRIPTION
types/algoliasearch isn't needed, and not used either, so can safely be removed from the starter