### PR TITLE
fix(React InstantSearch): import RefinementList if DynamicWidgets used

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -5738,7 +5738,7 @@ import {
   SearchBox,
   Configure,
   DynamicWidgets,
-  RefinementList
+  RefinementList,
   Pagination,
   Highlight,
 } from 'react-instantsearch-dom';

--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -5738,6 +5738,7 @@ import {
   SearchBox,
   Configure,
   DynamicWidgets,
+  RefinementList
   RefinementList,
   Pagination,
   Highlight,

--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -5739,7 +5739,6 @@ import {
   Configure,
   DynamicWidgets,
   RefinementList
-  RefinementList,
   Pagination,
   Highlight,
 } from 'react-instantsearch-dom';

--- a/src/templates/React InstantSearch/src/App.js.hbs
+++ b/src/templates/React InstantSearch/src/App.js.hbs
@@ -7,6 +7,7 @@ import {
   {{#if flags.dynamicWidgets}}
   Configure,
   DynamicWidgets,
+  RefinementList
   {{/if}}
   {{#if attributesForFaceting}}
   RefinementList,

--- a/src/templates/React InstantSearch/src/App.js.hbs
+++ b/src/templates/React InstantSearch/src/App.js.hbs
@@ -7,7 +7,7 @@ import {
   {{#if flags.dynamicWidgets}}
   Configure,
   DynamicWidgets,
-  RefinementList
+  RefinementList,
   {{else}}
   {{#if attributesForFaceting}}
   RefinementList,

--- a/src/templates/React InstantSearch/src/App.js.hbs
+++ b/src/templates/React InstantSearch/src/App.js.hbs
@@ -8,9 +8,10 @@ import {
   Configure,
   DynamicWidgets,
   RefinementList
-  {{/if}}
+  {{else}}
   {{#if attributesForFaceting}}
   RefinementList,
+  {{/if}}
   {{/if}}
   Pagination,
   {{#if attributesToDisplay}}


### PR DESCRIPTION
**Problem**
When choosing dynamic widgets setup, the fallback component (RefinementList) is not imported 

**Offending line**
https://github.com/algolia/create-instantsearch-app/blob/efda5395cef7865c7b4cebe741e7ab5e8ea4b2f8/src/templates/React%20InstantSearch/src/App.js.hbs#L45

**Error message**
<img width="421" alt="Screenshot 2022-02-01 at 10 10 00" src="https://user-images.githubusercontent.com/10894967/152005980-485c7522-32b3-4371-a74a-d778ec1e8366.png">

**Solution**
Add to conditional import section for dynamic widgets to include RefinementList

