### PR TITLE
chore: ignore .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # misc
 .DS_Store
 .vscode
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
This ignores local `.env` files in version control.