### PR TITLE
fix(Vue 3): add vite plugin to correctly handle jsx

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -8304,13 +8304,14 @@ app.mount('#app');"
 `;
 
 exports[`Templates Vue InstantSearch with Vue 3 File content: vite.config.js 1`] = `
-"import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+"import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import vueJsx from '@vitejs/plugin-vue-jsx';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()]
-})"
+  plugins: [vue(), vueJsx()],
+});"
 `;
 
 exports[`Templates Vue InstantSearch with Vue 3 Folder structure: contains the right files 1`] = `

--- a/src/templates/Vue InstantSearch with Vue 3/package.json
+++ b/src/templates/Vue InstantSearch with Vue 3/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "2.2.0",
+    "@vitejs/plugin-vue-jsx": "1.3.7",
     "vite": "2.8.0"
   }
 }

--- a/src/templates/Vue InstantSearch with Vue 3/vite.config.js
+++ b/src/templates/Vue InstantSearch with Vue 3/vite.config.js
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import vueJsx from '@vitejs/plugin-vue-jsx';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()]
-})
+  plugins: [vue(), vueJsx()],
+});


### PR DESCRIPTION
This small PR adds `@vitejs/plugin-vue-jsx` as a dependency for the **Vue InstantSearch with Vue 3** template, in order to correctly parse and transform JSX input.