### PR TITLE
fix(vue): support optional chaining

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -7517,6 +7517,7 @@ Open http://localhost:3000 to see your app."
 
 exports[`Templates Vue InstantSearch 2 File content: babel.config.js 1`] = `
 "module.exports = {
+  plugins: ['@babel/plugin-proposal-optional-chaining'],
   presets: ['@vue/app'],
 };"
 `;
@@ -7819,6 +7820,7 @@ Open http://localhost:3000 to see your app."
 
 exports[`Templates Vue InstantSearch File content: babel.config.js 1`] = `
 "module.exports = {
+  plugins: ['@babel/plugin-proposal-optional-chaining'],
   presets: ['@vue/app'],
 };"
 `;

--- a/src/templates/Vue InstantSearch 2/babel.config.js
+++ b/src/templates/Vue InstantSearch 2/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
+  plugins: ['@babel/plugin-proposal-optional-chaining'],
   presets: ['@vue/app'],
 };

--- a/src/templates/Vue InstantSearch 2/package.json
+++ b/src/templates/Vue InstantSearch 2/package.json
@@ -15,6 +15,7 @@
     "vue-instantsearch": "{{libraryVersion}}"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-optional-chaining": "7.16.7",
     "@vue/cli-plugin-babel": "3.6.0",
     "@vue/cli-plugin-eslint": "3.6.0",
     "@vue/cli-service": "3.6.0",

--- a/src/templates/Vue InstantSearch/babel.config.js
+++ b/src/templates/Vue InstantSearch/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
+  plugins: ['@babel/plugin-proposal-optional-chaining'],
   presets: ['@vue/app'],
 };

--- a/src/templates/Vue InstantSearch/package.json
+++ b/src/templates/Vue InstantSearch/package.json
@@ -15,6 +15,7 @@
     "vue-instantsearch": "{{libraryVersion}}"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-optional-chaining": "7.16.7",
     "@vue/cli-plugin-babel": "3.6.0",
     "@vue/cli-plugin-eslint": "3.6.0",
     "@vue/cli-service": "3.6.0",


### PR DESCRIPTION
This PR adds a Babel plugin to add support for optional chaining on Vue 2 projects templates.