### PR TITLE
 chore(ci): perform template update from github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: release-templates
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: 📦  install dependencies
+        run: yarn install
+
+      - name: 🔧  build templates
+        run: yarn release-templates
+
+      - name: 🚀  push templates
+        run: |
+          cd build
+          UNCOMMITTED_CHANGES=`git status --porcelain`
+          if [ ! -z "$UNCOMMITTED_CHANGES" ]; then
+            git config --global user.name "InstantSearch"
+            git config --global user.email "66688561+instantsearch-bot@users.noreply.github.com"
+            git commit -a -m "feat(template): Update templates"
+            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+            git push origin templates
+            echo "✅  Templates have been compiled to the branch templates."
+          else
+            echo "ℹ️  No changes made to the templates."
+          fi

--- a/README.md
+++ b/README.md
@@ -162,11 +162,9 @@ Create InstantSearch App is [MIT licensed](LICENSE).
 
 [version-svg]: https://img.shields.io/npm/v/create-instantsearch-app.svg?style=flat-square
 [package-url]: https://npmjs.org/package/create-instantsearch-app
-[ci-svg]: https://img.shields.io/travis/algolia/create-instantsearch-app/master.svg?style=flat-square
-[ci-url]: https://travis-ci.org/algolia/create-instantsearch-app
 [ci-svg]: https://img.shields.io/circleci/project/github/algolia/create-instantsearch-app.svg?style=flat-square
 [ci-url]: https://circleci.com/gh/algolia/create-instantsearch-app
-[license-image]: http://img.shields.io/badge/license-MIT-green.svg?style=flat-square
+[license-image]: https://img.shields.io/badge/license-MIT-green.svg?style=flat-square
 [license-url]: LICENSE
 
 <!-- Links -->

--- a/scripts/release-templates.js
+++ b/scripts/release-templates.js
@@ -104,53 +104,48 @@ async function build() {
     })
   );
 
-  // Change directory to the build folder to execute Git commands
-  process.chdir(BUILD_FOLDER);
+  if (!process.env.GITHUB_ACTION) {
+    // Change directory to the build folder to execute Git commands
+    process.chdir(BUILD_FOLDER);
 
-  const uncommitedChanges = execSync('git status --porcelain')
-    .toString()
-    .trim();
-
-  if (uncommitedChanges) {
-    // Stage all new demos to Git
-    execSync('git add -A');
-
-    // Commit the new demos
-    const commitMessage = 'feat(template): Update templates';
-
-    console.log('▶︎  Commiting');
-    console.log();
-    console.log(`  ${chalk.cyan(commitMessage)}`);
-
-    execSync(`git commit -m "${commitMessage}"`);
-
-    // Use the `origin-with-token` remote if it exists (when run with Ship.js)
-    const origin = execSync(
-      `git remote | grep origin-with-token || echo origin`
-    )
+    const uncommitedChanges = execSync('git status --porcelain')
       .toString()
       .trim();
 
-    // Push the new demos to the `templates` branch
-    console.log();
-    console.log(`▶︎  Pushing to branch "${chalk.green(TEMPLATES_BRANCH)}"`);
-    execSync(`git push ${origin} ${TEMPLATES_BRANCH}`);
+    if (uncommitedChanges) {
+      // Stage all new demos to Git
+      execSync('git add -A');
+
+      // Commit the new demos
+      const commitMessage = 'feat(template): Update templates';
+
+      console.log('▶︎  Commiting');
+      console.log();
+      console.log(`  ${chalk.cyan(commitMessage)}`);
+
+      execSync(`git commit -m "${commitMessage}"`);
+
+      // Push the new demos to the `templates` branch
+      console.log();
+      console.log(`▶︎  Pushing to branch "${chalk.green(TEMPLATES_BRANCH)}"`);
+      execSync(`git push origin ${TEMPLATES_BRANCH}`);
+
+      console.log();
+      console.log(
+        `✅  Templates have been compiled to the branch "${chalk.green(
+          TEMPLATES_BRANCH
+        )}".`
+      );
+    } else {
+      console.log();
+      console.log('ℹ️  No changes made to the templates.');
+    }
 
     console.log();
-    console.log(
-      `✅  Templates have been compiled to the branch "${chalk.green(
-        TEMPLATES_BRANCH
-      )}".`
-    );
-  } else {
-    console.log();
-    console.log('ℹ️  No changes made to the templates.');
+    process.chdir('..');
+
+    cleanup();
   }
-
-  console.log();
-  process.chdir('..');
-
-  cleanup();
 }
 
 build().catch(err => {

--- a/ship.config.js
+++ b/ship.config.js
@@ -7,5 +7,4 @@ module.exports = {
     return true;
   },
   buildCommand: () => null,
-  // afterPublish: ({ exec }) => exec('yarn run release-templates'),
 };

--- a/ship.config.js
+++ b/ship.config.js
@@ -7,5 +7,5 @@ module.exports = {
     return true;
   },
   buildCommand: () => null,
-  afterPublish: ({ exec }) => exec('yarn run release-templates'),
+  // afterPublish: ({ exec }) => exec('yarn run release-templates'),
 };


### PR DESCRIPTION
Currently, Shipjs is set up to run a `afterPublish` script to update the templates after the package is published on npm. This step [currently fails in CI](https://app.circleci.com/pipelines/github/algolia/create-instantsearch-app/2266/workflows/086c8f7c-6d5a-472e-8e76-b1bfa63fb17e/jobs/10893?invite=true#step-106-380) for unknown reasons, and prevents the execution of the following steps (git tag and git release). 

~This PR temporarily disables this script execution until a solution is found. This means that until this is solved, we should manually update the templates by running `yarn release-templates` locally.~

> **Note**
> I tried multiple approaches to debug the issue but could not reproduce it locally so I pivoted to set up a GitHub Action that will perform the update instead. The script can now executed on CI as well as locally if necessary.

I also fixed an issue with the badges in the README.md file.