### PR TITLE
fix(templates): wrap React InstantSearch Hooks native hit attributes in `Fragment`

### DIFF
--- a/e2e/__snapshots__/templates.test.js.snap
+++ b/e2e/__snapshots__/templates.test.js.snap
@@ -6235,12 +6235,14 @@ type HitProps = {
 
 function Hit({ hit }: HitProps) {
   return (
-    <Text>
-      <Highlight hit={hit} attribute=\\"attribute1\\" />
-    </Text>
-    <Text>
-      <Highlight hit={hit} attribute=\\"attribute2\\" />
-    </Text>
+    <>
+      <Text>
+        <Highlight hit={hit} attribute=\\"attribute1\\" />
+      </Text>
+      <Text>
+        <Highlight hit={hit} attribute=\\"attribute2\\" />
+      </Text>
+    </>
   );
 }
 

--- a/src/templates/React InstantSearch Hooks Native/App.tsx.hbs
+++ b/src/templates/React InstantSearch Hooks Native/App.tsx.hbs
@@ -42,20 +42,22 @@ type HitProps = {
 
 function Hit({ hit }: HitProps) {
   return (
-    {{#if attributesToDisplay}}
-    <Text>
-      <Highlight hit={hit} attribute="{{attributesToDisplay.[0]}}" />
-    </Text>
-    {{#each attributesToDisplay}}
-    {{#unless @first}}
-    <Text>
-      <Highlight hit={hit} attribute="{{this}}" />
-    </Text>
-    {{/unless}}
-    {{/each}}
-    {{else}}
-    <Text>{JSON.stringify(hit).slice(0, 100)}</Text>
-    {{/if}}
+    <>
+      {{#if attributesToDisplay}}
+      <Text>
+        <Highlight hit={hit} attribute="{{attributesToDisplay.[0]}}" />
+      </Text>
+      {{#each attributesToDisplay}}
+      {{#unless @first}}
+      <Text>
+        <Highlight hit={hit} attribute="{{this}}" />
+      </Text>
+      {{/unless}}
+      {{/each}}
+      {{else}}
+      <Text>{JSON.stringify(hit).slice(0, 100)}</Text>
+      {{/if}}
+    </>
   );
 }
 

--- a/src/templates/React InstantSearch Hooks Native/package.json
+++ b/src/templates/React InstantSearch Hooks Native/package.json
@@ -25,7 +25,7 @@
     "@babel/core": "^7.12.9",
     "@types/react": "~17.0.21",
     "@types/react-native": "~0.64.12",
-    "expo-cli": "5.1.1",
+    "expo-cli": "5.5.1",
     "typescript": "~4.3.5"
   }
 }


### PR DESCRIPTION
This PR fixes an issue with the React InstantSearch Hooks Native template, where the app shows an error if it generated with  more than one hit attribute to display.

It also updates the Expo CLI to fix an issue with how they check for TypeScript version (https://github.com/expo/expo-cli/pull/4439).